### PR TITLE
Remove unused config variables

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -43,7 +43,6 @@ let bootstrap_dir = Fpath.v "_ocaml"
 let bootstrap_src_dir = Fpath.(bootstrap_dir / "src")
 let ocaml_src_dir = Fpath.(bootstrap_src_dir / "ocaml")
 let dune_src_dir = Fpath.(bootstrap_src_dir / "dune")
-let dune_latest_tag = "2.6.0" (* TODO get from opam metadata *)
 let lockfile_ext = ".opam.locked"
 
 (* variable to use for vendoring *)

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -35,14 +35,8 @@ let compiler_package_name = OpamPackage.Name.of_string "ocaml"
 let duniverse_opam_repo =
   "git+https://github.com/dune-universe/opam-overlays.git"
 
-let dune_get = Fpath.v "dune-get"
 let vendor_dir = Fpath.v "duniverse"
-let pins_dir = Fpath.(vendor_dir / ".pins")
 let duniverse_log = Fpath.v ".duniverse-log"
-let bootstrap_dir = Fpath.v "_ocaml"
-let bootstrap_src_dir = Fpath.(bootstrap_dir / "src")
-let ocaml_src_dir = Fpath.(bootstrap_src_dir / "ocaml")
-let dune_src_dir = Fpath.(bootstrap_src_dir / "dune")
 let lockfile_ext = ".opam.locked"
 
 (* variable to use for vendoring *)


### PR DESCRIPTION
While attempting to solve a `TODO` I realized it is never used. Then I realized there's more variables that aren't used, so decided to delete these as well. They are probably left over from a time where the tool built OCaml and Dune, but now we assume these are installed.