### PR TITLE
Allow resolving unprefixed refs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Fix resolving refs of locally pinned repositories (#326, #332, @hannesm,
+  @Leonidas-from-XIV)
+
 ### Removed
 
 ### Security

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -56,12 +56,19 @@ module Ls_remote = struct
           let result = search_ref (prefix ^ ref) parsed_lines in
           interpret_search_result result
         in
-        match (search "refs/tags/", search "refs/heads/") with
-        | Some _, Some _ -> Error `Multiple_such_refs
-        | Some commit, None | None, Some commit -> Ok commit
-        | None, None when is_commit ref parsed_lines -> Ok ref
-        | None, None when looks_like_commit ref -> log_approx ()
-        | None, None -> Error `No_such_ref)
+        match (search "", search "refs/tags/", search "refs/heads/") with
+        | Some _, Some _, Some _
+        | Some _, Some _, None
+        | Some _, None, Some _
+        | None, Some _, Some _ ->
+            Error `Multiple_such_refs
+        | Some commit, None, None
+        | None, Some commit, None
+        | None, None, Some commit ->
+            Ok commit
+        | None, None, None when is_commit ref parsed_lines -> Ok ref
+        | None, None, None when looks_like_commit ref -> log_approx ()
+        | None, None, None -> Error `No_such_ref)
 
   let parse_ref_output_line ~symref line =
     match String.extract_blank_separated_words line with

--- a/test/bin/pinning.t/opam-monorepo-test-other/opam-monorepo-test-other.opam
+++ b/test/bin/pinning.t/opam-monorepo-test-other/opam-monorepo-test-other.opam
@@ -1,0 +1,8 @@
+opam-version: "2.0"
+synopsis: "Dummy package for testing"
+maintainer: ["marek@tarides.com"]
+authors: ["Marek Kubica"]
+dev-repo: "git+http://example.com/opam-monorepo-test-other"
+depends: [
+  "dune"
+]

--- a/test/bin/pinning.t/run.t
+++ b/test/bin/pinning.t/run.t
@@ -1,0 +1,31 @@
+We have a simple project which depends on another package
+
+  $ opam show --just-file -fdepends ./this/this.opam
+  dune, opam-monorepo-test-other
+
+`git ls-remote` is a bit stupid and for some reason requires a valid `.git`
+folder and the dune cram tests don't have one. So let's create one here:
+
+  $ git init > /dev/null 2>&1
+
+Now let's create a git pin:
+
+  $ cd opam-monorepo-test-other
+  $ git init > /dev/null 2>&1
+  $ git add opam-monorepo-test-other.opam
+  $ git commit -m "Initial commit" > /dev/null
+  $ cd ..
+
+Let's add this pin and pin it to `HEAD`.
+
+  $ cd this
+  $ opam pin --yes --no-action add --kind git opam-monorepo-test-other '../opam-monorepo-test-other#HEAD' > /dev/null 2>&1
+
+Locking with this pin should work.
+
+  $ opam-monorepo lock > /dev/null 2>&1
+
+We need to clean up since this modifies global state.
+
+  $ opam pin remove opam-monorepo-test-other > /dev/null
+  $ cd ..

--- a/test/bin/pinning.t/this/this.opam
+++ b/test/bin/pinning.t/this/this.opam
@@ -1,0 +1,5 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "opam-monorepo-test-other"
+]


### PR DESCRIPTION
When using a pinned dependency the refs might not have a prefix (e.g. `HEAD` is a plain ref) thus they wouldn't have been found when attempting to resolve the refs.

Closes #326