### PR TITLE
Warn when using source for different version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   status of the packages (#258, #323, @RyanGibb, @Julow)
 - Take `archive-mirrors` from the global opam configuration into account to
   allow more local caches (#337, @hannesm)
+- Log at WARN level when opam-monorepo chooses a source for a package that
+  doesn't match the package's version (#352, @reynir)
 
 ### Removed
 

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -109,7 +109,7 @@ module Repo = struct
         version (url_to_string url)
     in
     let sep fmt () = Format.fprintf fmt "\n" in
-    Logs.info (fun l ->
+    Logs.warn (fun l ->
         l
           "The following packages come from the same repository %s but are \
            associated with different URLs:\n\


### PR DESCRIPTION
It is exceedingly annoying to work with pinned packages that are effectively not pinned due to this behavior. Because it was logged at INFO level this log message would not appear in the output without raising the log level.

Related to https://github.com/tarides/opam-monorepo/issues/145 and https://github.com/mirage/mirage/issues/1375