### PR TITLE
WIP: Respect pins

### DIFF
--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -37,6 +37,7 @@ module Repo : sig
       dev_repo : string;
       url : unresolved Url.t;
       hashes : OpamHash.t list;
+      pinned : bool;
     }
 
     val equal : t -> t -> bool

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -187,27 +187,29 @@ module Package_summary = struct
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
+    pinned : bool;
   }
 
-  let equal { package; url_src; hashes; dev_repo; depexts } t' =
+  let equal { package; url_src; hashes; dev_repo; depexts; pinned } t' =
     OpamPackage.equal package t'.package
     && Option.equal Url.equal url_src t'.url_src
     && List.equal Hash.equal hashes t'.hashes
     && Option.equal String.equal dev_repo t'.dev_repo
     && Depexts.equal depexts t'.depexts
+    && Bool.equal pinned t'.pinned
 
-  let pp fmt { package; url_src; hashes; dev_repo; depexts } =
+  let pp fmt { package; url_src; hashes; dev_repo; depexts; pinned } =
     let open Pp_combinators.Ocaml in
     Format.fprintf fmt
       "@[<hov 2>{ name = %a;@ version = %a;@ url_src = %a;@ hashes = %a;@ \
-       dev_repo = %a;@ depexts = %a }@]"
+       dev_repo = %a;@ depexts = %a;@ pinned = %b }@]"
       Pp.package_name package.name Pp.version package.version
       (option ~brackets:true Url.pp)
       url_src (list Hash.pp) hashes
       (option ~brackets:true string)
-      dev_repo Depexts.pp depexts
+      dev_repo Depexts.pp depexts pinned
 
-  let from_opam package opam_file =
+  let from_opam package ~pinned opam_file =
     let url_field = OpamFile.OPAM.url opam_file in
     let url_src = Option.map ~f:Url.from_opam_field url_field in
     let hashes =
@@ -217,7 +219,7 @@ module Package_summary = struct
       Option.map ~f:OpamUrl.to_string (OpamFile.OPAM.dev_repo opam_file)
     in
     let depexts = OpamFile.OPAM.depexts opam_file in
-    { package; url_src; hashes; dev_repo; depexts }
+    { package; url_src; hashes; dev_repo; depexts; pinned }
 
   let is_virtual = function
     | { url_src = None; _ } -> true

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -20,11 +20,12 @@ module Package_summary : sig
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
+    pinned : bool;
   }
 
   val equal : t -> t -> bool
   val pp : t Fmt.t
-  val from_opam : OpamPackage.t -> OpamFile.OPAM.t -> t
+  val from_opam : OpamPackage.t -> pinned:bool -> OpamFile.OPAM.t -> t
 
   val is_virtual : t -> bool
   (** A package is considered virtual if it has no url.src or no dev-repo. *)

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -23,14 +23,15 @@ let opam_factory ~name ~version =
   OpamPackage.create name version
 
 let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
-    ?(hashes = []) ?(depexts = []) () =
+    ?(hashes = []) ?(depexts = []) ?(pinned = false) () =
   let package = opam_factory ~name ~version in
-  { Opam.Package_summary.package; dev_repo; url_src; hashes; depexts }
+  { Opam.Package_summary.package; dev_repo; url_src; hashes; depexts; pinned }
 
 let dependency_factory ?(vendored = true) ?name ?version ?dev_repo ?url_src
-    ?hashes ?depexts () =
+    ?hashes ?depexts ?pinned () =
   let package_summary =
-    summary_factory ?name ?version ?dev_repo ?url_src ?hashes ?depexts ()
+    summary_factory ?name ?version ?dev_repo ?url_src ?hashes ?depexts ?pinned
+      ()
   in
   { Opam.Dependency_entry.vendored; package_summary }
 
@@ -75,6 +76,7 @@ module Repo = struct
                     dev_repo = "d";
                     url = Other "u";
                     hashes = [];
+                    pinned = false;
                   }))
           ();
         make_test ~name:"Uses default branch when no tag"
@@ -92,16 +94,17 @@ module Repo = struct
                     dev_repo = "d";
                     url = Git { repo = "r"; ref = "master" };
                     hashes = [];
+                    pinned = false;
                   }))
           ();
       ]
   end
 
   let package_factory ?(name = "") ?(version = "") ?(dev_repo = "")
-      ?(url = Duniverse.Repo.Url.Other "") ?(hashes = []) () =
+      ?(url = Duniverse.Repo.Url.Other "") ?(hashes = []) ?(pinned = false) () =
     let open Duniverse.Repo.Package in
     let opam = opam_factory ~name ~version in
-    { opam; dev_repo; url; hashes }
+    { opam; dev_repo; url; hashes; pinned }
 
   let test_from_packages =
     let make_test ~name ~dev_repo ~packages ~expected () =


### PR DESCRIPTION
This is an attempt at improving the situation described in #145 by always using the source of pinned packages when there's a 'collision'. If there are multiple packages with the same repository pinned to different URIs opam-monorepo fails.

- [ ] Fail more gracefully than raising `Failure _`.
- [ ] Tracking pinned status could probably be done more gracefully.

This improves for me the situation described in https://github.com/mirage/mirage/issues/1375