### PR TITLE
Dune 3.5 update

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -108,11 +108,11 @@ module Logs = struct
   let app ?src f =
     Logs.app ?src (fun l ->
         f (fun ?header ?tags fmt ->
-            l ?header ?tags ("%a" ^^ fmt) Duniverse_lib.Pp.Styled.header ()))
+            l ?header ?tags ("%a" ^^ fmt) D.Pp.Styled.header ()))
 end
 
 (** Filters the duniverse according to the CLI provided list of repos *)
-let filter_duniverse ~to_consider (duniverse : Duniverse.t) =
+let filter_duniverse ~to_consider (duniverse : D.Duniverse.t) =
   match to_consider with
   | None -> Ok duniverse
   | Some to_consider -> (
@@ -139,7 +139,7 @@ let find_lockfile_aux ~explicit_lockfile repo =
   match explicit_lockfile with
   | Some file -> Ok file
   | None -> (
-      let* local_lockfiles = Project.local_lockfiles repo in
+      let* local_lockfiles = D.Project.local_lockfiles repo in
       match local_lockfiles with
       | [] ->
           Rresult.R.error_msg
@@ -150,7 +150,7 @@ let find_lockfile_aux ~explicit_lockfile repo =
           Rresult.R.error_msgf
             "Found several lockfiles: %a\n\
              Please pick one explicitly using the %a option"
-            (Fmt.list ~sep Pp.Styled.path)
+            (Fmt.list ~sep D.Pp.Styled.path)
             lockfile_paths
             Fmt.(styled `Bold string)
             "--lockfile")
@@ -159,5 +159,5 @@ let find_lockfile ~explicit_lockfile ?(quiet = false) root =
   let open Result.O in
   find_lockfile_aux ~explicit_lockfile root >>= fun file ->
   if not quiet then
-    Logs.app (fun l -> l "Using lockfile %a" Pp.Styled.path file);
-  Lockfile.load ~opam_monorepo_cwd:root ~file
+    Logs.app (fun l -> l "Using lockfile %a" D.Pp.Styled.path file);
+  D.Lockfile.load ~opam_monorepo_cwd:root ~file

--- a/cli/depext.ml
+++ b/cli/depext.ml
@@ -20,7 +20,7 @@ let available_packages pkgs =
 let run (`Root root) (`Lockfile explicit_lockfile) dry_run (`Yes yes) () =
   let open Result.O in
   let* lockfile = Common.find_lockfile ~explicit_lockfile root in
-  let depexts = Lockfile.depexts lockfile in
+  let depexts = D.Lockfile.depexts lockfile in
   OpamGlobalState.with_ `Lock_none (fun global_state ->
       let env = OpamPackageVar.resolve_global global_state in
       let pkgs =

--- a/cli/dune
+++ b/cli/dune
@@ -1,4 +1,12 @@
 (library
  (name duniverse_cli)
- (libraries duniverse_lib fmt.cli fmt.tty logs.cli logs.fmt cmdliner
-   dune-build-info ocaml-version opam-state))
+ (libraries
+  duniverse_lib
+  fmt.cli
+  fmt.tty
+  logs.cli
+  logs.fmt
+  cmdliner
+  dune-build-info
+  ocaml-version
+  opam-state))

--- a/cli/import.ml
+++ b/cli/import.ml
@@ -1,2 +1,2 @@
 include Stdext
-include Duniverse_lib
+module D = Duniverse_lib

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -1,5 +1,4 @@
 open Import
-open Duniverse
 
 type t = {
   name : OpamPackage.Name.t;
@@ -44,12 +43,12 @@ let pp ~max_name ~max_version ~short ppf t =
       Fmt.pf ppf "%a %a %s" pp_name padded_name pp_version padded_version
         (match t.descr with None -> "--" | Some d -> d)
 
-let pkgs_of_repo (t : resolved Repo.t) =
+let pkgs_of_repo (t : D.Duniverse.resolved D.Duniverse.Repo.t) =
   List.map
     ~f:(fun (pkg : OpamPackage.t) ->
       let name = pkg.name in
       let version = pkg.version in
-      let loc = Repo.Url.to_string t.url in
+      let loc = D.Duniverse.Repo.Url.to_string t.url in
       let pinned =
         match t.url with Git _ -> true | _ -> guess_pin ~version ~loc
       in
@@ -79,7 +78,7 @@ let with_descr pkgs =
 let run (`Root root) (`Lockfile explicit_lockfile) short () =
   let open Result.O in
   let* lockfile = Common.find_lockfile ~explicit_lockfile ~quiet:short root in
-  let+ duniverse = Lockfile.to_duniverse lockfile in
+  let+ duniverse = D.Lockfile.to_duniverse lockfile in
   let pkgs = pkgs_of_duniverse duniverse in
   let pkgs = with_descr pkgs in
   let max_name, max_version =
@@ -94,8 +93,8 @@ let run (`Root root) (`Lockfile explicit_lockfile) short () =
   let pp = pp ~max_name ~max_version ~short in
   if not short then
     Common.Logs.app (fun l ->
-        let duniverse = Fpath.(v (Sys.getcwd ()) // Config.vendor_dir / "") in
-        l "The vendor directory is %a" Pp.Styled.path duniverse);
+        let duniverse = Fpath.(v (Sys.getcwd ()) // D.Config.vendor_dir / "") in
+        l "The vendor directory is %a" D.Pp.Styled.path duniverse);
   List.iter ~f:(fun pkg -> Fmt.pr "%a\n" pp pkg) pkgs
 
 open Cmdliner

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 3.6)
 (generate_opam_files true)
 (name opam-monorepo)
 

--- a/dune-project
+++ b/dune-project
@@ -4,11 +4,11 @@
 
 (cram enable)
 
-(source (github ocamllabs/opam-monorepo))
+(source (github tarides/opam-monorepo))
 (license ISC)
 (authors "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon")
 (maintainers "anil@recoil.org")
-(documentation "https://ocamllabs.github.io/opam-monorepo")
+(documentation "https://tarides.github.io/opam-monorepo")
 
 (package
  (name opam-monorepo)

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.6)
+(lang dune 3.5)
 (generate_opam_files true)
 (name opam-monorepo)
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,16 @@
 (library
  (name duniverse_lib)
- (libraries base bos cmdliner fmt logs ocaml-version opam-0install
-   opam-file-format opam-format sexplib stdext threads uri))
+ (libraries
+  base
+  bos
+  cmdliner
+  fmt
+  logs
+  ocaml-version
+  opam-0install
+  opam-file-format
+  opam-format
+  sexplib
+  stdext
+  threads
+  uri))

--- a/lib/pp_combinators.mli
+++ b/lib/pp_combinators.mli
@@ -26,7 +26,7 @@ module Opam : sig
     val pp : t Fmt.t
   end
 
-  module Make_Set (M : OpamStd.SET) (P : Printable with type t = M.elt) : sig
+  module Make_Set (M : OpamStd.SET) (_ : Printable with type t = M.elt) : sig
     val pp : ?sep:unit Fmt.t -> M.t Fmt.t
   end
 end

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/tarides/opam-monorepo"
 doc: "https://tarides.github.io/opam-monorepo"
 bug-reports: "https://github.com/tarides/opam-monorepo/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.6"}
   "ocaml" {>= "4.10.0"}
   "dune-build-info"
   "base"

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/tarides/opam-monorepo"
 doc: "https://tarides.github.io/opam-monorepo"
 bug-reports: "https://github.com/tarides/opam-monorepo/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.10.0"}
   "dune-build-info"
   "base"

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -10,9 +10,9 @@ authors: [
   "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
 ]
 license: "ISC"
-homepage: "https://github.com/ocamllabs/opam-monorepo"
-doc: "https://ocamllabs.github.io/opam-monorepo"
-bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+homepage: "https://github.com/tarides/opam-monorepo"
+doc: "https://tarides.github.io/opam-monorepo"
+bug-reports: "https://github.com/tarides/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.10.0"}
@@ -36,6 +36,6 @@ conflicts: [
   "dune-build-info" {= "2.7.0" | = "2.7.1"}
   "dune-configurator" {= "2.7.0" | = "2.7.1"}
 ]
-dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+dev-repo: "git+https://github.com/tarides/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
 flags: [ plugin ]

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -108,9 +108,7 @@ module Repo = struct
       let test_name = Printf.sprintf "Repo.from_packages: %s" name in
       let test_fun () =
         let dev_repo = Dev_repo.from_string dev_repo in
-        let actual =
-          Duniverse_lib.Duniverse.Repo.from_packages ~dev_repo packages
-        in
+        let actual = Duniverse.Repo.from_packages ~dev_repo packages in
         Alcotest.(check Testable.Repo.unresolved) test_name expected actual
       in
       (test_name, `Quick, test_fun)
@@ -209,8 +207,7 @@ let test_from_dependency_entries =
     let test_name = Printf.sprintf "from_dependency_entries: %s" name in
     let test_fun () =
       let actual =
-        Duniverse_lib.Duniverse.from_dependency_entries ~get_default_branch
-          dependency_entries
+        Duniverse.from_dependency_entries ~get_default_branch dependency_entries
       in
       Alcotest.(check (result (list Testable.Repo.unresolved) Testable.r_msg))
         test_name expected actual

--- a/test/lib/test_source_opam_config.ml
+++ b/test/lib/test_source_opam_config.ml
@@ -1,5 +1,5 @@
-open Duniverse_lib
-open Import
+module D = Duniverse_lib
+open D.Import
 
 let opam_url_set =
   let pp fmt url_set =
@@ -29,7 +29,7 @@ module Opam_repositories_url_rewriter = struct
         Printf.sprintf "Opam_repositories_url_rewriter.rewrite_one_in: %s" name
       in
       let test_fun () =
-        let open Source_opam_config.Private in
+        let open D.Source_opam_config.Private in
         let value = OpamUrl.of_string value in
         let actual =
           Opam_repositories_url_rewriter.rewrite_one_in ~opam_monorepo_cwd value
@@ -70,7 +70,7 @@ module Opam_repositories_url_rewriter = struct
         Printf.sprintf "Opam_repositories_url_rewriter.rewrite_one_out: %s" name
       in
       let test_fun () =
-        let open Source_opam_config.Private in
+        let open D.Source_opam_config.Private in
         let value = OpamUrl.of_string value in
         let actual =
           Opam_repositories_url_rewriter.rewrite_one_out ~opam_monorepo_cwd
@@ -109,7 +109,7 @@ module Opam_repositories = struct
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
         let expected = Result.map ~f:t_from_input expected in
         let actual =
-          Source_opam_config.Private.Opam_repositories.from_opam_value value
+          D.Source_opam_config.Private.Opam_repositories.from_opam_value value
         in
         Alcotest.(check (result opam_url_set Testable.r_msg))
           test_name expected actual
@@ -132,7 +132,7 @@ module Opam_repositories = struct
       let test_fun () =
         let url_set = t_from_input url_set in
         let actual =
-          Source_opam_config.Private.Opam_repositories.to_opam_value url_set
+          D.Source_opam_config.Private.Opam_repositories.to_opam_value url_set
           |> OpamPrinter.FullPos.value
         in
         Alcotest.(check string) test_name expected actual
@@ -153,7 +153,7 @@ module Opam_repositories = struct
         Printf.sprintf "Opam_repositories.cmdliner_parse: %s" name
       in
       let test_fun () =
-        let open Source_opam_config.Private in
+        let open D.Source_opam_config.Private in
         let expected = Result.map ~f:t_from_input expected in
         let actual =
           Cmdliner.Arg.conv_parser Opam_repositories.cmdliner_conv value
@@ -181,8 +181,7 @@ module Opam_global_vars = struct
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
         let expected = Result.map expected ~f:String.Map.of_list_exn in
         let actual =
-          let open Duniverse_lib.Source_opam_config in
-          Private.Opam_global_vars.from_opam_value value
+          D.Source_opam_config.Private.Opam_global_vars.from_opam_value value
         in
         Alcotest.(check (result variable_content_string_map Testable.r_msg))
           test_name expected actual
@@ -212,8 +211,7 @@ module Opam_global_vars = struct
       let test_fun () =
         let env = String.Map.of_list_exn env in
         let actual =
-          let open Duniverse_lib.Source_opam_config in
-          Private.Opam_global_vars.to_opam_value env
+          D.Source_opam_config.Private.Opam_global_vars.to_opam_value env
           |> OpamPrinter.FullPos.value
         in
         Alcotest.(check string) test_name expected actual
@@ -232,7 +230,7 @@ module Opam_global_vars = struct
         Printf.sprintf "Opam_global_vars.cmdliner_parse: %s" name
       in
       let test_fun () =
-        let open Source_opam_config.Private in
+        let open D.Source_opam_config.Private in
         let expected = Result.map expected ~f:String.Map.of_list_exn in
         let actual =
           Cmdliner.Arg.conv_parser Opam_global_vars.cmdliner_conv value
@@ -259,7 +257,7 @@ module Opam_provided = struct
     let make_test ~name ~value ~expected =
       let test_name = Printf.sprintf "Opam_provided.from_opam_value: %s" name in
       let test_fun () =
-        let open Source_opam_config in
+        let open D.Source_opam_config in
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
         let expected = Result.map expected ~f:t_from_input in
         let actual = Private.Opam_provided.from_opam_value value in
@@ -282,7 +280,7 @@ module Opam_provided = struct
     let make_test ~name ~value ~expected =
       let test_name = Printf.sprintf "Opam_provided.to_opam_value: %s" name in
       let test_fun () =
-        let open Source_opam_config in
+        let open D.Source_opam_config in
         let value = t_from_input value in
         let actual =
           Private.Opam_provided.to_opam_value value |> OpamPrinter.FullPos.value


### PR DESCRIPTION
This is useful for releases where we're supposed to bump the dune-lang version. But opam-monorepo is currently not compatible with newer versions of dune so this PR attempts to fix things.