### PR TITLE
Make tests compatible with macos

### DIFF
--- a/test/bin/config-cli-args.t/run.t
+++ b/test/bin/config-cli-args.t/run.t
@@ -47,7 +47,7 @@ Once again, we can see from the generated lock file that it used both repos.
 Note that you can use the '--opam-repositories' option to overwrite any local
 extension.
 
-  $ sed -i '$d' ./config-cli-args.opam
+  $ sed -i -e '$d' ./config-cli-args.opam
   $ echo 'x-opam-monorepo-opam-repositories: ["https://a.com/a.tbz"]' >> ./config-cli-args.opam
   $ opam show --just-file -fx-opam-monorepo-opam-repositories ./config-cli-args.opam
   https://a.com/a.tbz

--- a/test/bin/dune
+++ b/test/bin/dune
@@ -1,6 +1,9 @@
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:opam-monorepo} %{bin:gen-minimal-repo}))
+ (deps
+  %{bin:opam-monorepo}
+  %{bin:gen-minimal-repo}
+  (sandbox preserve_file_kind)))
 
 (executable
  (name gen_minimal_repo)

--- a/test/bin/explicit-repo.t/run.t
+++ b/test/bin/explicit-repo.t/run.t
@@ -51,7 +51,7 @@ Therefore the list of repositories in the lockfile should have the a git repo
 that's the same as the previous git-repository path but end with "#$SHORT_HASH"
 
   $ opam show --just-file --raw -fx-opam-monorepo-opam-repositories ./explicit-repo.opam.locked > locked-repos
-  $ grep -Po ".+(?=$SHORT_HASH1)" locked-repos
+  $ sed "s/\(.*\)$SHORT_HASH1.*/\1/" locked-repos
   git+file://$OPAM_MONOREPO_CWD/git-repository#
 
 We also need to make sure that the git cache gets updated when the repository is updated:
@@ -74,5 +74,5 @@ new version of the git opam repository.
   $ opam show --just-file --raw -fdepends ./explicit-repo.opam.locked | grep git-dep
   "git-dep" {= "2.0"}
   $ opam show --just-file --raw -fx-opam-monorepo-opam-repositories ./explicit-repo.opam.locked > locked-repos
-  $ grep -Po ".+(?=$SHORT_HASH2)" locked-repos
+  $ sed "s/\(.*\)$SHORT_HASH2.*/\1/" locked-repos
   git+file://$OPAM_MONOREPO_CWD/git-repository#

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -41,8 +41,9 @@ to the test)
   $ opam-monorepo lock toonew 2> errors
   ==> Using 1 locally scanned package as the target.
   [1]
-  $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
+  $ grep "opam-monorepo: \[ERROR\]" < errors
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0
+  opam-monorepo: [ERROR] Can't find all required versions.
 
 We should also produce the right error message with all the constraints when we have multiple constaints
 
@@ -51,5 +52,6 @@ We should also produce the right error message with all the constraints when we 
   $ opam-monorepo lock multiple-constraint 2> errors
   ==> Using 1 locally scanned package as the target.
   [1]
-  $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
+  $ grep "opam-monorepo: \[ERROR\]" < errors
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0
+  opam-monorepo: [ERROR] Can't find all required versions.

--- a/test/bin/lockfile-version.t/run.t
+++ b/test/bin/lockfile-version.t/run.t
@@ -10,7 +10,7 @@ This is our current version.
 At the moment we are not backward compatible so if we downgrade this version number,
 pull will refuse the lockfile and suggest it is regenerated with the current plugin:
 
-  $ sed -i "s/x-opam-monorepo-version: \"0.3\"/x-opam-monorepo-version: \"0.2\"/" lockfile-version.opam.locked
+  $ sed -i -e "s/x-opam-monorepo-version: \"0.3\"/x-opam-monorepo-version: \"0.2\"/" lockfile-version.opam.locked
   $ opam-monorepo pull > /dev/null
   opam-monorepo: [ERROR] opam-monorepo lockfile version 0.2 is too old. Please regenerate the lockfile using your current opam-monorepo plugin or install an older version of the plugin.
   [1]
@@ -18,7 +18,7 @@ pull will refuse the lockfile and suggest it is regenerated with the current plu
 We also obviously do not support future versions and they should be rejected as well,
 suggesting that the user upgrade their plugin to be able to interpret that lockfile:
 
-  $ sed -i "s/x-opam-monorepo-version: \"0.2\"/x-opam-monorepo-version: \"0.999\"/" lockfile-version.opam.locked
+  $ sed -i -e "s/x-opam-monorepo-version: \"0.2\"/x-opam-monorepo-version: \"0.999\"/" lockfile-version.opam.locked
   $ opam-monorepo pull > /dev/null
   opam-monorepo: [ERROR] Incompatible opam-monorepo lockfile version 0.999. Please upgrade your opam-monorepo plugin.
   [1]

--- a/test/bin/minimal-update.t/run.t
+++ b/test/bin/minimal-update.t/run.t
@@ -15,7 +15,7 @@ our dependencies:
 
 Now we add a dependency to 'c' to our project
 
-  $ sed -i'' '/"b"/a "c"' minimal-update.opam
+  $ sed -i'' -e 's/"b"/&\n  "c"/' ./minimal-update.opam
   $ opam show --just-file -fdepends ./minimal-update.opam
   dune, a, b, c
 
@@ -42,7 +42,7 @@ previous version.
 Now say we want to also update 'b' because we need a feature that is only
 available in the latest version:
 
-  $ sed -i'' 's/"b"/"b" {>= "0.2"}/' minimal-update.opam
+  $ sed -i'' -e 's/"b"/"b" {>= "0.2"}/' minimal-update.opam
   $ opam show --just-file -fdepends ./minimal-update.opam
   "dune" "a" "b" {>= "0.2"} "c"
 
@@ -56,7 +56,7 @@ Locking with --minimal-update should update 'b' but not 'a':
 
 Alternatively, if we remove a dependency:
 
-  $ sed -i'' '/"c"/d' ./minimal-update.opam
+  $ sed -i'' -e '/"c"/d' ./minimal-update.opam
   $ opam show --just-file -fdepends ./minimal-update.opam
   "dune" "a" "b" {>= "0.2"}
 


### PR DESCRIPTION
Some commands used in tests use features not available on macos:
 - `sed -i ...` requires a file extension to be passed as an argument, and the original file is preserved as a copy with the given extension appended
 - `grep -P ...` is not implemented

I updated the tests to use perl instead as its behaviour will be consistent across different unixes.

Also, when using homebrew as a package manager, opam incorrectly reports non-existent packages as available, presumably because brew provides no fast way to query for the existence of non-installed packages. This was causing a depext test to fail on macos.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>