### PR TITLE
Fix sort order of `avoid-versions`

### DIFF
--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -169,13 +169,33 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
                    (version, Ok opam_file))
 
   let demote_candidates_to_avoid versions =
-    let avoid_versions, regular_versions =
-      List.partition versions ~f:(fun (_version, opam_res) ->
-          match opam_res with
-          | Ok opam -> Opam.avoid_version opam
-          | Error _ -> false)
+    (* false as long as the package name stays the same *)
+    let break (_, opam_res_a) (_, opam_res_b) =
+      match (opam_res_a, opam_res_b) with
+      | Ok opam_a, Ok opam_b ->
+          let name_a = OpamFile.OPAM.name opam_a in
+          let name_b = OpamFile.OPAM.name opam_b in
+          not (OpamPackage.Name.equal name_a name_b)
+      | _, _ -> false
     in
-    regular_versions @ avoid_versions
+    let put_avoid_version_back versions =
+      let avoid_versions, regular_versions =
+        List.partition versions ~f:(fun (_version, opam_res) ->
+            match opam_res with
+            | Ok opam -> Opam.avoid_version opam
+            | Error _ -> false)
+      in
+      regular_versions @ avoid_versions
+    in
+    (* the solver only looks at package candidates that are consecutive in
+       the list, thus each avoid-version demotion has to stay in the same
+       run of package names and can't be just shuffled to the back of the
+       candidate list.
+
+       Thus we group by package name, demote and reconcatenate *)
+    versions |> Base.List.group ~break
+    |> List.map ~f:put_avoid_version_back
+    |> List.concat
 
   let promote_version version candidates =
     match version with

--- a/test/bin/avoid-versions.t/avoid-versions.opam
+++ b/test/bin/avoid-versions.t/avoid-versions.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a"
+  "b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/avoid-versions.t/force-versions.opam
+++ b/test/bin/avoid-versions.t/force-versions.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a" {>= "2.0~"}
+  "b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/avoid-versions.t/repo/packages/a/a.1.0/opam
+++ b/test/bin/avoid-versions.t/repo/packages/a/a.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "ocaml"
+  "dune"
+]
+url {
+  src: "https://a.com/a.1.0.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/avoid-versions.t/repo/packages/a/a.2.0~beta1/opam
+++ b/test/bin/avoid-versions.t/repo/packages/a/a.2.0~beta1/opam
@@ -1,0 +1,13 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "ocaml"
+  "dune"
+]
+flags: [ avoid-version ]
+url {
+  src: "https://a.com/a.2.0beta1.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/avoid-versions.t/repo/packages/b/b.1.0/opam
+++ b/test/bin/avoid-versions.t/repo/packages/b/b.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/b.git"
+depends: [
+  "ocaml"
+  "dune"
+]
+url {
+  src: "https://a.com/b.1.0.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/avoid-versions.t/repo/repo
+++ b/test/bin/avoid-versions.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/avoid-versions.t/run.t
+++ b/test/bin/avoid-versions.t/run.t
@@ -1,0 +1,41 @@
+We want to make sure that packages that are marked with the `avoid-version`
+flag are avoided, but if explicitly asked the solver will pick them.
+
+We have a project that depends on a package `a` and `b`
+
+  $ opam show --just-file --raw -fdepends ./avoid-versions.opam
+  dune, a, b
+
+We use the minimal repository to set up the environment.
+
+  $ gen-minimal-repo
+
+Package `a` version 1.0 is a regular package
+
+  $ opam show --just-file -fflags repo/packages/a/a.1.0/opam
+  
+
+No red flags here, but 2.0~beta1 is supposed to be avoided:
+
+  $ opam show --just-file -fflags repo/packages/a/a.2.0~beta1/opam
+  avoid-version
+
+Locking that way should yield a solution that uses `a.1.0` and avoids the 2.0
+beta release:
+
+  $ opam-monorepo lock avoid-versions.opam > /dev/null
+  $ grep -E "\"a\" \{" avoid-versions.opam.locked
+    "a" {= "1.0" & ?vendor}
+
+If however we request a version that is newer (using the `~` constraint, which
+should match the beta version), the `avoid-version` should be overridden and
+pick 2.0.
+
+  $ opam show --just-file --raw -fdepends ./force-versions.opam
+  "dune" "a" {>= "2.0~"} "b"
+  $ opam-monorepo lock force-versions.opam > /dev/null
+  $ grep -E "\"a\" \{" force-versions.opam.locked
+    "a" {= "2.0~beta1" & ?vendor}
+
+What is the dependency on `b` good for? It is to make sure that the
+deprioritizing of `a.2.0~beta1` works even in the presence of other packages.


### PR DESCRIPTION
Previously the solver discarded everything in the back of the list, thus not only avoiding the avoid-version packages but effectively removing them from the candidate set. Now we keep the groups of packages consecutive which makes the solver pick them if there is no other option, while still trying to avoid them if other options are available.