### PR TITLE
Add warning when `dev-repo` is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- Display warning when a package to be locked is missing a `dev-repo` field and
+  is being skipped because of it (#341, #362, @kit-ty-kate,
+  @Leonidas-from-XIV)
+
 ### Changed
 
 ### Deprecated

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -96,6 +96,13 @@ module Repo = struct
           } ->
               let* url = url url_src in
               Ok (Some { opam = package; dev_repo; url; hashes })
+          | { dev_repo = None; package; _ } ->
+              Logs.warn (fun l ->
+                  l
+                    "Package %a has no dev-repo specified, but it needs a \
+                     dev-repo to be successfully included in the duniverse."
+                    Opam.Pp.package package);
+              Ok None
           | _ -> Ok None)
   end
 

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -236,10 +236,11 @@ module Package_summary = struct
 
   let has_flag flag { flags; _ } = List.mem flag ~set:flags
   let is_compiler v = has_flag OpamTypes.Pkgflag_Compiler v
+  let is_conf v = has_flag OpamTypes.Pkgflag_Conf v
 
   let is_virtual = function
     | { url_src = None; _ } -> true
-    | { dev_repo = None | Some ""; _ } -> true
+    | { dev_repo = None | Some ""; _ } as pkg when is_conf pkg -> true
     | { build_commands = []; _ } -> true
     | _ -> false
 

--- a/test/bin/missing-dev-repo.t/missing-dev-repo.opam
+++ b/test/bin/missing-dev-repo.t/missing-dev-repo.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "no-dev-repo"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/missing-dev-repo.t/repo/packages/no-dev-repo/no-dev-repo.1/opam
+++ b/test/bin/missing-dev-repo.t/repo/packages/no-dev-repo/no-dev-repo.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+build: [ "dune" "build" ]
+url {
+  src: "https://b.com/b.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/missing-dev-repo.t/repo/repo
+++ b/test/bin/missing-dev-repo.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/missing-dev-repo.t/run.t
+++ b/test/bin/missing-dev-repo.t/run.t
@@ -1,0 +1,25 @@
+We have a simple project with a single package defined at the root.
+It has a `x-opam-monorepo-opam-repositories` field set to use a local
+opam-repository for locking
+
+  $ cat missing-dev-repo.opam
+  opam-version: "2.0"
+  depends: [
+    "dune"
+    "no-dev-repo"
+  ]
+  x-opam-monorepo-opam-repositories: [
+    "file://$OPAM_MONOREPO_CWD/minimal-repo"
+    "file://$OPAM_MONOREPO_CWD/repo"
+  ]
+
+We provided a minimal opam-repository but locking should be successful.
+
+  $ gen-minimal-repo
+  $ opam-monorepo lock
+  ==> Using 1 locally scanned package as the target.
+  ==> Found 9 opam dependencies for the target package.
+  ==> Querying opam database for their metadata and Dune compatibility.
+  ==> Calculating exact pins for each of them.
+  opam-monorepo: [WARNING] Package no-dev-repo.1 has no dev-repo specified, but it needs a dev-repo to be successfully included in the duniverse.
+  ==> Wrote lockfile with 0 entries to $TESTCASE_ROOT/missing-dev-repo.opam.locked. You can now run opam monorepo pull to fetch their sources.


### PR DESCRIPTION
Adds a warning as suggested by @kit-ty-kate.

Fixes #341 