### PR TITLE
Normalize Github URLs before comparing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
 ### Changed
 
+- Canonicalize the URLs of the OPAM `dev-repo` fields to be able to detect more
+  semantically equivalent URLs, this should reduce the risk of build failures
+  due to duplicate code pulled (#118, #365 @TheLortex, @Leonidas-from-XIV)
+
 ### Deprecated
 
 ### Fixed

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -57,9 +57,9 @@ module Repo = struct
       type t = string
 
       let equal a b =
-        let a = a |> Uri.of_string |> Uri_utils.canonicalize in
-        let b = b |> Uri.of_string |> Uri_utils.canonicalize in
-        Uri.equal a b
+        let a = a |> Uri.of_string |> Uri_utils.Normalized.of_uri in
+        let b = b |> Uri.of_string |> Uri_utils.Normalized.of_uri in
+        Uri_utils.Normalized.equal a b
     end
 
     type t = {

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -53,16 +53,25 @@ module Repo = struct
   end
 
   module Package = struct
+    module Dev_repo = struct
+      type t = string
+
+      let equal a b =
+        let a = a |> Uri.of_string |> Uri_utils.canonicalize in
+        let b = b |> Uri.of_string |> Uri_utils.canonicalize in
+        Uri.equal a b
+    end
+
     type t = {
       opam : OpamPackage.t;
-      dev_repo : string;
+      dev_repo : Dev_repo.t;
       url : unresolved Url.t;
       hashes : OpamHash.t list;
     }
 
     let equal t t' =
       OpamPackage.equal t.opam t'.opam
-      && String.equal t.dev_repo t'.dev_repo
+      && Dev_repo.equal t.dev_repo t'.dev_repo
       && Url.equal Git.Ref.equal t.url t'.url
 
     let pp fmt { opam; dev_repo; url; hashes } =

--- a/lib/uri_utils.ml
+++ b/lib/uri_utils.ml
@@ -1,16 +1,42 @@
 open Import
 
+let path_ok path = path |> Fpath.to_string |> Result.ok
+let flip f a b = f b a
+
+let dump_result =
+  let dump_msg ppf (`Msg s) = Fmt.pf ppf "`Msg %S" s in
+  Fmt.Dump.result ~ok:Fmt.Dump.string ~error:dump_msg
+
 let canonicalize uri =
   let open Result.O in
-  let path = Uri.path uri in
   let new_path =
-    let* fpath = Fpath.of_string path in
-    match Fpath.has_ext ".git" fpath with
-    | true -> Ok fpath
-    | false -> Ok (Fpath.add_ext ".git" fpath)
+    let* fpath = Fpath.of_string (Uri.path uri) in
+    let fpath =
+      match Fpath.has_ext ".git" fpath with
+      | true -> fpath
+      | false -> Fpath.add_ext ".git" fpath
+    in
+    path_ok fpath
   in
-  match new_path with
-  | Error _ -> uri
-  | Ok new_path ->
-      let new_path = Fpath.to_string new_path in
-      Uri.with_path uri new_path
+  let new_scheme =
+    match Uri.scheme uri with
+    | Some "https" -> Ok "git+https"
+    | Some "git" -> Ok "git+https"
+    | Some ("git+https" as git_https) -> Ok git_https
+    | Some other_scheme ->
+        Fmt.error_msg "Can't canonicalize unknown scheme %s" other_scheme
+    | None -> Fmt.error_msg "No scheme provided in %a" Uri.pp uri
+  in
+  match (new_path, new_scheme) with
+  | Ok new_path, Ok new_scheme ->
+      uri
+      |> (flip Uri.with_path) new_path
+      |> (flip Uri.with_scheme) (Some new_scheme)
+      |> (flip Uri.with_fragment) None
+  | failed_path, failed_scheme ->
+      Logs.warn (fun l ->
+          l
+            "Canonicalization of URL %a failed, passing unchanged \
+             (canonicialized path: %a canonicalized scheme: %a)"
+            Uri.pp uri dump_result failed_path dump_result failed_scheme);
+      uri

--- a/lib/uri_utils.ml
+++ b/lib/uri_utils.ml
@@ -1,11 +1,16 @@
 open Import
 
-let has_git_extension uri =
+let canonicalize uri =
   let open Result.O in
-  let ext_res =
-    let+ path = Fpath.of_string (Uri.path uri) in
-    Fpath.get_ext ~multi:true path
+  let path = Uri.path uri in
+  let new_path =
+    let* fpath = Fpath.of_string path in
+    match Fpath.has_ext ".git" fpath with
+    | true -> Ok fpath
+    | false -> Ok (Fpath.add_ext ".git" fpath)
   in
-  match ext_res with Ok ".git" -> true | Ok _ | Error _ -> false
-
-let canonicalize uri = uri
+  match new_path with
+  | Error _ -> uri
+  | Ok new_path ->
+      let new_path = Fpath.to_string new_path in
+      Uri.with_path uri new_path

--- a/lib/uri_utils.ml
+++ b/lib/uri_utils.ml
@@ -7,3 +7,5 @@ let has_git_extension uri =
     Fpath.get_ext ~multi:true path
   in
   match ext_res with Ok ".git" -> true | Ok _ | Error _ -> false
+
+let canonicalize uri = uri

--- a/lib/uri_utils.ml
+++ b/lib/uri_utils.ml
@@ -7,36 +7,47 @@ let dump_result =
   let dump_msg ppf (`Msg s) = Fmt.pf ppf "`Msg %S" s in
   Fmt.Dump.result ~ok:Fmt.Dump.string ~error:dump_msg
 
-let canonicalize uri =
-  let open Result.O in
-  let new_path =
-    let* fpath = Fpath.of_string (Uri.path uri) in
-    let fpath =
-      match Fpath.has_ext ".git" fpath with
-      | true -> fpath
-      | false -> Fpath.add_ext ".git" fpath
+module Normalized = struct
+  type t = Uri.t
+
+  let of_uri uri =
+    let open Result.O in
+    let new_path =
+      let* fpath = Fpath.of_string (Uri.path uri) in
+      let fpath =
+        match Fpath.has_ext ".git" fpath with
+        | true -> fpath
+        | false -> Fpath.add_ext ".git" fpath
+      in
+      path_ok fpath
     in
-    path_ok fpath
-  in
-  let new_scheme =
-    match Uri.scheme uri with
-    | Some "https" -> Ok "git+https"
-    | Some "git" -> Ok "git+https"
-    | Some ("git+https" as git_https) -> Ok git_https
-    | Some other_scheme ->
-        Fmt.error_msg "Can't canonicalize unknown scheme %s" other_scheme
-    | None -> Fmt.error_msg "No scheme provided in %a" Uri.pp uri
-  in
-  match (new_path, new_scheme) with
-  | Ok new_path, Ok new_scheme ->
-      uri
-      |> (flip Uri.with_path) new_path
-      |> (flip Uri.with_scheme) (Some new_scheme)
-      |> (flip Uri.with_fragment) None
-  | failed_path, failed_scheme ->
-      Logs.warn (fun l ->
-          l
-            "Canonicalization of URL %a failed, passing unchanged \
-             (canonicialized path: %a canonicalized scheme: %a)"
-            Uri.pp uri dump_result failed_path dump_result failed_scheme);
-      uri
+    let new_scheme =
+      match Uri.scheme uri with
+      | Some "https" -> Ok "git+https"
+      | Some "git" -> Ok "git+https"
+      | Some ("git+https" as git_https) -> Ok git_https
+      | Some other_scheme ->
+          Fmt.error_msg "Can't canonicalize unknown scheme %s" other_scheme
+      | None -> Fmt.error_msg "No scheme provided in %a" Uri.pp uri
+    in
+    match (new_path, new_scheme) with
+    | Ok new_path, Ok new_scheme ->
+        uri
+        |> (flip Uri.with_path) new_path
+        |> (flip Uri.with_scheme) (Some new_scheme)
+        |> (flip Uri.with_fragment) None
+    | failed_path, failed_scheme ->
+        Logs.warn (fun l ->
+            l
+              "Canonicalization of URL %a failed, passing unchanged \
+               (canonicialized path: %a canonicalized scheme: %a)"
+              Uri.pp uri dump_result failed_path dump_result failed_scheme);
+        uri
+
+  let equal = Uri.equal
+  let pp ppf v = Fmt.pf ppf "<Normalized %a>" Uri.pp v
+
+  module Private = struct
+    let unescaped = Base.Fn.id
+  end
+end

--- a/lib/uri_utils.mli
+++ b/lib/uri_utils.mli
@@ -12,14 +12,4 @@ module Normalized : sig
 
   val pp : t Fmt.t
   (** Pretty printer for normalized URLs. *)
-
-  (**/**)
-
-  module Private : sig
-    val unescaped : Uri.t -> t
-    (** Convert a [Uri.t] into a [t] without escaping. Only used for testing
-        purposes, as it breaks the security guarantees. *)
-  end
-
-  (**/**)
 end

--- a/lib/uri_utils.mli
+++ b/lib/uri_utils.mli
@@ -1,5 +1,2 @@
-val has_git_extension : Uri.t -> bool
-(** Returns [true] if the given URI's path component has the .git extension *)
-
 val canonicalize : Uri.t -> Uri.t
 (** Returns a canonical representation of the URI *)

--- a/lib/uri_utils.mli
+++ b/lib/uri_utils.mli
@@ -1,2 +1,5 @@
 val has_git_extension : Uri.t -> bool
 (** Returns [true] if the given URI's path component has the .git extension *)
+
+val canonicalize : Uri.t -> Uri.t
+(** Returns a canonical representation of the URI *)

--- a/lib/uri_utils.mli
+++ b/lib/uri_utils.mli
@@ -1,2 +1,25 @@
-val canonicalize : Uri.t -> Uri.t
-(** Returns a canonical representation of the URI *)
+(** One way normalization of URIs.
+    Not meant to expose the normalized value of the URI again *)
+module Normalized : sig
+  type t
+  (** Abstracts away the actual value which is not to be used directly *)
+
+  val of_uri : Uri.t -> t
+  (** Returns a canonical representation of the URI *)
+
+  val equal : t -> t -> bool
+  (** Determines whether two normalized URIs are equal *)
+
+  val pp : t Fmt.t
+  (** Pretty printer for normalized URLs. *)
+
+  (**/**)
+
+  module Private : sig
+    val unescaped : Uri.t -> t
+    (** Convert a [Uri.t] into a [t] without escaping. Only used for testing
+        purposes, as it breaks the security guarantees. *)
+  end
+
+  (**/**)
+end

--- a/test/lib/test_uri_utils.ml
+++ b/test/lib/test_uri_utils.ml
@@ -1,18 +1,3 @@
-let test_has_git_extension =
-  let make_test ~uri_str ~expected () =
-    let test_name = Printf.sprintf "has_git_extension: %s" uri_str in
-    let uri = Uri.of_string uri_str in
-    let test_fun () =
-      let actual = Duniverse_lib.Uri_utils.has_git_extension uri in
-      Alcotest.(check bool) test_name expected actual
-    in
-    (test_name, `Quick, test_fun)
-  in
-  [
-    make_test ~uri_str:"https://host.com/path/to/repo.git" ~expected:true ();
-    make_test ~uri_str:"https://host.com/path/to/repo" ~expected:false ();
-  ]
-
 module Uri = struct
   include Uri
 
@@ -48,5 +33,4 @@ let test_canonical_uri =
       ~expected:"git+https://github.com/mirage/mirage-clock.git";
   ]
 
-let suite =
-  ("Uri_utils", List.concat [ test_has_git_extension; test_canonical_uri ])
+let suite = ("Uri_utils", test_canonical_uri)

--- a/test/lib/test_uri_utils.ml
+++ b/test/lib/test_uri_utils.ml
@@ -13,4 +13,40 @@ let test_has_git_extension =
     make_test ~uri_str:"https://host.com/path/to/repo" ~expected:false ();
   ]
 
-let suite = ("Uri_utils", test_has_git_extension)
+module Uri = struct
+  include Uri
+
+  let testable = Alcotest.testable pp equal
+end
+
+let test_canonical_uri =
+  let make_test ~name ~supplied ~expected =
+    let supplied = Uri.of_string supplied in
+    let expected = Uri.of_string expected in
+    let test_name = Fmt.str "canonicizing: %s" name in
+    let test_fun () =
+      let actual = Duniverse_lib.Uri_utils.canonicalize supplied in
+      Alcotest.(check Uri.testable) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~name:"no-op"
+      ~supplied:"git+https://github.com/mirage/mirage-clock.git"
+      ~expected:"git+https://github.com/mirage/mirage-clock.git";
+    make_test ~name:"scheme: git"
+      ~supplied:"git://github.com/mirage/mirage-clock.git"
+      ~expected:"git+https://github.com/mirage/mirage-clock.git";
+    make_test ~name:"scheme: https"
+      ~supplied:"https://github.com/mirage/mirage-clock.git"
+      ~expected:"git+https://github.com/mirage/mirage-clock.git";
+    make_test ~name:"hash"
+      ~supplied:"git+https://github.com/mirage/mirage-clock.git#master"
+      ~expected:"git+https://github.com/mirage/mirage-clock.git";
+    make_test ~name:".git suffix"
+      ~supplied:"git+https://github.com/mirage/mirage-clock"
+      ~expected:"git+https://github.com/mirage/mirage-clock.git";
+  ]
+
+let suite =
+  ("Uri_utils", List.concat [ test_has_git_extension; test_canonical_uri ])

--- a/test/lib/test_uri_utils.ml
+++ b/test/lib/test_uri_utils.ml
@@ -1,5 +1,5 @@
-module Uri = struct
-  include Uri
+module Normalized = struct
+  include Duniverse_lib.Uri_utils.Normalized
 
   let testable = Alcotest.testable pp equal
 end
@@ -7,11 +7,11 @@ end
 let test_canonical_uri =
   let make_test ~name ~supplied ~expected =
     let supplied = Uri.of_string supplied in
-    let expected = Uri.of_string expected in
+    let expected = Uri.of_string expected |> Normalized.Private.unescaped in
     let test_name = Fmt.str "canonicizing: %s" name in
     let test_fun () =
-      let actual = Duniverse_lib.Uri_utils.canonicalize supplied in
-      Alcotest.(check Uri.testable) test_name expected actual
+      let actual = Normalized.of_uri supplied in
+      Alcotest.(check Normalized.testable) test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in

--- a/test/lib/test_uri_utils.ml
+++ b/test/lib/test_uri_utils.ml
@@ -1,36 +1,54 @@
-module Normalized = struct
-  include Duniverse_lib.Uri_utils.Normalized
-
-  let testable = Alcotest.testable pp equal
-end
+module Normalized = Duniverse_lib.Uri_utils.Normalized
 
 let test_canonical_uri =
-  let make_test ~name ~supplied ~expected =
-    let supplied = Uri.of_string supplied in
-    let expected = Uri.of_string expected |> Normalized.Private.unescaped in
-    let test_name = Fmt.str "canonicizing: %s" name in
+  let make_test ~supplied:(a, b) ~expected =
+    let a = Uri.of_string a in
+    let a' = Normalized.of_uri a in
+    let b = Uri.of_string b in
+    let b' = Normalized.of_uri b in
+    let test_name = Fmt.str "Comparing %a and %a" Uri.pp a Uri.pp b in
     let test_fun () =
-      let actual = Normalized.of_uri supplied in
-      Alcotest.(check Normalized.testable) test_name expected actual
+      let actual = Normalized.equal a' b' in
+      Alcotest.(check bool) test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in
   [
-    make_test ~name:"no-op"
-      ~supplied:"git+https://github.com/mirage/mirage-clock.git"
-      ~expected:"git+https://github.com/mirage/mirage-clock.git";
-    make_test ~name:"scheme: git"
-      ~supplied:"git://github.com/mirage/mirage-clock.git"
-      ~expected:"git+https://github.com/mirage/mirage-clock.git";
-    make_test ~name:"scheme: https"
-      ~supplied:"https://github.com/mirage/mirage-clock.git"
-      ~expected:"git+https://github.com/mirage/mirage-clock.git";
-    make_test ~name:"hash"
-      ~supplied:"git+https://github.com/mirage/mirage-clock.git#master"
-      ~expected:"git+https://github.com/mirage/mirage-clock.git";
-    make_test ~name:".git suffix"
-      ~supplied:"git+https://github.com/mirage/mirage-clock"
-      ~expected:"git+https://github.com/mirage/mirage-clock.git";
+    make_test
+      ~supplied:
+        ( "git+https://github.com/mirage/mirage-clock.git",
+          "git+https://github.com/mirage/mirage-clock.git" )
+      ~expected:true;
+    make_test
+      ~supplied:
+        ( "git://github.com/mirage/mirage-clock.git",
+          "git+https://github.com/mirage/mirage-clock.git" )
+      ~expected:true;
+    make_test
+      ~supplied:
+        ( "https://github.com/mirage/mirage-clock.git",
+          "git+https://github.com/mirage/mirage-clock.git" )
+      ~expected:true;
+    make_test
+      ~supplied:
+        ( "git+https://github.com/mirage/mirage-clock.git#master",
+          "git+https://github.com/mirage/mirage-clock.git" )
+      ~expected:true;
+    make_test
+      ~supplied:
+        ( "git+https://github.com/mirage/mirage-clock",
+          "git+https://github.com/mirage/mirage-clock.git" )
+      ~expected:true;
+    make_test
+      ~supplied:
+        ( "git+https://github.com/mirage/mirage-foo.git",
+          "git+https://github.com/mirage/mirage-bar.git" )
+      ~expected:false;
+    make_test
+      ~supplied:
+        ( "git+https://github.com/mirage/mirage.git",
+          "git+https://github.com/anchorage/mirage.git" )
+      ~expected:false;
   ]
 
 let suite = ("Uri_utils", test_canonical_uri)


### PR DESCRIPTION
This PR tries to normalize the `dev-repo` URLs somewhat. @TheLortex reported in #118 that the `.git` is differing between the repos so this PR tries to normalize the URLs:

1. Always have `.git` in the repo path
2. Always use `git+https` as scheme
3. Always strip fragments (No more `#main`)

This is just a workaround since there is no way to make sure the URLs are equivalent without visiting them (especially the `.git` addition is a bit dodgy), but it should at least cover some common cases and in the worst case the canonicalization gives up and returns the input, thus equivalent to what was there before.

Also turns out there was a `Uri_utils.has_git_extension` which I assume is somewhat related to the issue at hand, but it was unused so I removed it. 

Closes #118 