### PR TITLE
Do not rewrite `dune` files in ML format when updating references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 
 - Process all `dune` in the project after renaming libraries to avoid pointing
   to non-existing vendored libraries (#370, #371 @Leonidas-from-XIV)
+- Skip over `dune` files in ML format both when attempting to rename libraries
+  as well as when updating references (#372, @Leonidas-from-XIV)
 
 ### Removed
 

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -212,10 +212,13 @@ let rec dune_packages_from_args env args =
 let dune_packages_from_build_command env cmd =
   let args, _filters = cmd in
   let simple_args = List.map ~f:fst args in
-  match simple_args with
-  | OpamTypes.CString "dune" :: dune_args ->
-      dune_packages_from_args env dune_args
-  | _ -> []
+  let rec find_dune_invocation = function
+    | [] -> []
+    | OpamTypes.CString "dune" :: dune_args ->
+        dune_packages_from_args env dune_args
+    | _ :: other_args -> find_dune_invocation other_args
+  in
+  find_dune_invocation simple_args
 
 let dune_packages_from_build_commands env cmds =
   cmds


### PR DESCRIPTION
Currently `opam-monorepo` is skipping over files with the Tuareg stanza when renaming, but not when updating the references. Oddly enough Sexplib parses these files successfully, but outputting them breaks down so we need to make sure to skip files with the Tuareg stanza even when updating the references.