### PR TITLE
Distinguish private vs public names when vendoring names

### DIFF
--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -82,11 +82,6 @@ module Packages = struct
     (* needs to start with `old.` to be part of the same package *)
     Fmt.str "%s.%s" original suffix
 
-  let random_library_name v original =
-    let suffix = random_valid_identifier v in
-    (* needs not to have a dot *)
-    Fmt.str "%s_%s" original suffix
-
   let find_by_name name stanzas =
     let matches =
       List.filter_map stanzas ~f:(function
@@ -151,10 +146,12 @@ module Packages = struct
                   let renames = Map.add ~key:public_name ~data renames in
                   (stanzas, renames)
               | None as private_name ->
-                  (* we need to add a valid "name" field if there is none *)
-                  let new_name = random_library_name t public_name in
+                  (* we need to add a valid "name" field and it has to match the
+                     previous public name to make sure there is no extra level
+                     of wrapping happening if the library comes with its own
+                     entry point module. *)
                   let stanzas =
-                    List [ Atom "name"; Atom new_name ] :: stanzas
+                    List [ Atom "name"; Atom public_name ] :: stanzas
                   in
                   (* private_name is None, because it means that the old
                      reference can't have referred to the private name as it

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -36,7 +36,11 @@ module Packages : sig
 
   val init : string -> t
 
-  type new_name = { public_name : string; private_name : string option }
+  type new_name = {
+    public_name : string;
+    private_name : string option;
+    dune_project : string;
+  }
 
   type 'a rename_result = {
     changed : bool;
@@ -46,13 +50,17 @@ module Packages : sig
 
   val rename :
     t ->
+    dune_project:string ->
     keep:string list ->
     new_name Map.t ->
     Sexplib0.Sexp.t list ->
     Sexplib0.Sexp.t list rename_result
 
   val update_references :
-    new_name Map.t -> Sexplib0.Sexp.t list -> Sexplib0.Sexp.t list rename_result
+    dune_project:string ->
+    new_name Map.t ->
+    Sexplib0.Sexp.t list ->
+    Sexplib0.Sexp.t list rename_result
 end
 
 module Project : sig

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -36,21 +36,23 @@ module Packages : sig
 
   val init : string -> t
 
+  type new_name = { public_name : string; private_name : string option }
+
   type 'a rename_result = {
     changed : bool;
     stanzas : 'a;
-    renames : string Map.t;
+    renames : new_name Map.t;
   }
 
   val rename :
     t ->
     keep:string list ->
-    string Map.t ->
+    new_name Map.t ->
     Sexplib0.Sexp.t list ->
     Sexplib0.Sexp.t list rename_result
 
   val update_references :
-    string Map.t -> Sexplib0.Sexp.t list -> Sexplib0.Sexp.t list rename_result
+    new_name Map.t -> Sexplib0.Sexp.t list -> Sexplib0.Sexp.t list rename_result
 end
 
 module Project : sig

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -42,11 +42,8 @@ module Packages : sig
     dune_project : string;
   }
 
-  type 'a rename_result = {
-    changed : bool;
-    stanzas : 'a;
-    renames : new_name Map.t;
-  }
+  type 'a change = { changed : bool; data : 'a }
+  type 'a rename = { stanzas : 'a; renames : new_name Map.t }
 
   val rename :
     t ->
@@ -54,13 +51,13 @@ module Packages : sig
     keep:string list ->
     new_name Map.t ->
     Sexplib0.Sexp.t list ->
-    Sexplib0.Sexp.t list rename_result
+    Sexplib0.Sexp.t list rename change
 
   val update_references :
     dune_project:string ->
     new_name Map.t ->
     Sexplib0.Sexp.t list ->
-    Sexplib0.Sexp.t list rename_result
+    Sexplib0.Sexp.t list change
 end
 
 module Project : sig

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -72,18 +72,13 @@ let name_of_path path =
       None
   | Ok None -> None
   | Ok (Some sexps) -> (
-      let names =
-        List.filter_map sexps ~f:(function
-          | Sexplib0.Sexp.List (Atom "name" :: Atom value :: _) -> Some value
-          | _ -> None)
-      in
-      match names with
-      | [] -> None
-      | [ x ] -> Some x
-      | x :: _ ->
-          Logs.warn (fun l ->
-              l "Multiple `name` stanzas in %a, using first" Fpath.pp path);
-          Some x)
+      match Dune_file.Project.name sexps with
+      | Ok name -> Some name
+      | Error msg ->
+          Logs.debug (fun l ->
+              l "Determining project name of `%a` failed: %a" Fpath.pp path
+                Rresult.R.pp_msg msg);
+          None)
 
 let rec dune_project_of_dune path =
   let parent_dir = Fpath.parent path in

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -28,7 +28,7 @@ let preprocess_dune dfp ~keep ~dune_project ~renames dune_file =
   match sexps with
   | None -> Ok None
   | Some sexps -> (
-      let Dune_file.Packages.{ changed; stanzas; renames } =
+      let Dune_file.Packages.{ changed; data = { stanzas; renames } } =
         Dune_file.Packages.rename dfp ~dune_project ~keep renames sexps
       in
       match changed with
@@ -148,7 +148,7 @@ let postprocess_project ~keep ~disambiguation directory =
             let dune_project =
               path |> dune_project_of_dune |> if_no_dune_project
             in
-            let Dune_file.Packages.{ changed; stanzas; renames = _ } =
+            let Dune_file.Packages.{ changed; data } =
               Dune_file.Packages.update_references ~dune_project renames sexps
             in
             match changed with
@@ -156,7 +156,7 @@ let postprocess_project ~keep ~disambiguation directory =
             | true ->
                 Logs.debug (fun l ->
                     l "Rewriting %a to make names unique" Fpath.pp path);
-                write_sexps path stanzas))
+                write_sexps path data))
       (Ok ()) [ directory ]
   in
   res

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -58,7 +58,7 @@ let write_sexps path sexps =
       (fun oc sexps ->
         let ppf = Format.formatter_of_out_channel oc in
         List.iter ~f:(fun sexp -> Fmt.pf ppf "%a\n" pp_sexp sexp) sexps;
-        Ok ())
+        Ok (Fmt.flush ppf ()))
       sexps
   in
   write_result


### PR DESCRIPTION
As I am testing the renaming facility I came across some bugs:

 * [X] Can't just blindly promote everything to public names as this causes `dune` to build more and also stuff that shouldn't be built
 * [X] Some files would be empty as the formatter writing the sexps wouldn't be flushed before the output channel is closed, thus the content would never reach the file
 * [X] `libraries` stanzas support the `re_export` flag, which needs to be handled
 * [x] Can't just invent private names, because the library name has to match the entry point module (e.g. `dyn` -> `dyn.ml{,i}`, otherwise another layer of wrapping is being added by dune when building, causing failures.

I think this doesn't need a changelog entry since it is not a change from the latest released version, more a set of follow-up bugfixes for #367 that have been detected in production projects.