### PR TITLE
Rename OPAM files accordingly when renaming `public_names`

### DIFF
--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -79,8 +79,7 @@ module Packages = struct
 
   let random_public_name v original =
     let suffix = random_valid_identifier v in
-    (* needs to start with `old.` to be part of the same package *)
-    Fmt.str "%s.%s" original suffix
+    Fmt.str "%s_%s" original suffix
 
   let find_by_name name stanzas =
     let matches =
@@ -282,6 +281,15 @@ module Packages = struct
         in
         let stanzas = List.rev stanzas in
         modified ~changed ~stanzas ~renames
+
+  let renamed_opam_file renames path =
+    let directory, opam_file_name = Fpath.split_base path in
+    let package_name = Fpath.rem_ext opam_file_name |> Fpath.to_string in
+    match Map.find_opt package_name renames with
+    | None -> path
+    | Some { public_name; private_name = _; dune_project = _ } ->
+        let new_file_name = public_name |> Fpath.v |> Fpath.add_ext "opam" in
+        Fpath.(directory // new_file_name)
 end
 
 module Raw = struct

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -58,6 +58,8 @@ module Packages : sig
     new_name Map.t ->
     Sexplib0.Sexp.t list ->
     Sexplib0.Sexp.t list change
+
+  val renamed_opam_file : new_name Map.t -> Fpath.t -> Fpath.t
 end
 
 module Project : sig

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -60,6 +60,9 @@ module Packages : sig
     Sexplib0.Sexp.t list change
 
   val renamed_opam_file : new_name Map.t -> Fpath.t -> Fpath.t
+
+  val update_dune_project_references :
+    new_name Map.t -> Sexplib0.Sexp.t list -> Sexplib0.Sexp.t list change
 end
 
 module Project : sig

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -133,7 +133,6 @@ let rewrite_dune_project renames directory =
   | false -> Ok ()
   | true -> (
       let* parsed = parse_sexps dune_project_file in
-      Fmt.epr "Rewriting %a\n" Fpath.pp dune_project_file;
       match parsed with
       | None -> Ok ()
       | Some sexps -> (
@@ -148,7 +147,10 @@ let postprocess_project ~keep ~disambiguation directory =
   let open Result.O in
   let is_dune_file path =
     let filename = Fpath.filename path in
-    Ok (String.equal filename "dune")
+    let matches =
+      Base.List.mem ~equal:String.equal [ "dune"; "dune.inc" ] filename
+    in
+    Ok matches
   in
   let elements = `Sat is_dune_file in
   let dfp = Dune_file.Packages.init disambiguation in


### PR DESCRIPTION
This PR fixes issues when the deduplication is disabled that have been found while attempting to lock Irmin:

* [X] Multiple tarballs might ship the same OPAM file, thus defining which of the files is the canonical for `<package-name>.opam` is impossible — thus the packages need to be renamed.
* [X] `dune` files are not always called `dune`, sometimes `dune.inc` is used for flies that are included. This is a rather mediocre fix but a proper solution that determines which `dune` files are part of the build would require lot of `dune`-specific logic that might not be worth reproducing. Hoping for an 80:20 solution here.
* [ ] `(package <name>)` stanzas can be all over in `dune` files, we need to handle them in more places.