### PR TITLE
Mark packages as virtual when they have neither `build` nor `install`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@
 - Fix assertion failure when prefix of "lock" subcommand is used (#381,
   @gridbugs)
 
+- Treat packages without build commands as virtual only if also lack install
+  commands, as some non-virtual packages might only have install commands.
+  (#376 @Leonidas-from-XIV, @gridbugs)
+
 ### Removed
 
 ### Security

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -21,7 +21,8 @@ module Package_summary : sig
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
     flags : OpamTypes.package_flag list;
-    build_commands : OpamTypes.command list;
+    has_build_commands : bool;
+    has_install_commands : bool;
   }
 
   val pp : t Fmt.t

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -28,7 +28,8 @@ let opam_factory ~name ~version =
   OpamPackage.create name version
 
 let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
-    ?(hashes = []) ?(depexts = []) ?(flags = []) ?(build_commands = []) () =
+    ?(hashes = []) ?(depexts = []) ?(flags = []) ?(has_build_commands = false)
+    ?(has_install_commands = false) () =
   let package = opam_factory ~name ~version in
   {
     Opam.Package_summary.package;
@@ -37,14 +38,15 @@ let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
     hashes;
     depexts;
     flags;
-    build_commands;
+    has_build_commands;
+    has_install_commands;
   }
 
 let dependency_factory ?(vendored = true) ?name ?version ?dev_repo ?url_src
-    ?hashes ?depexts ?flags ?build_commands () =
+    ?hashes ?depexts ?flags ?has_build_commands () =
   let package_summary =
     summary_factory ?name ?version ?dev_repo ?url_src ?hashes ?depexts ?flags
-      ?build_commands ()
+      ?has_build_commands ()
   in
   { Opam.Dependency_entry.vendored; package_summary }
 
@@ -80,9 +82,7 @@ module Repo = struct
         make_test ~name:"Regular"
           ~summary:
             (summary_factory ~dev_repo:"d" ~url_src:(Other "u") ~name:"y"
-               ~version:"v" ~hashes:[]
-               ~build_commands:[ ([], None) ]
-               ())
+               ~version:"v" ~hashes:[] ~has_build_commands:true ())
           ~expected:
             (Ok
                (Some
@@ -99,9 +99,7 @@ module Repo = struct
           ~summary:
             (summary_factory ~dev_repo:"d"
                ~url_src:(Git { repo = "r"; ref = None })
-               ~name:"y" ~version:"v" ~hashes:[]
-               ~build_commands:[ ([], None) ]
-               ())
+               ~name:"y" ~version:"v" ~hashes:[] ~has_build_commands:true ())
           ~expected:
             (Ok
                (Some
@@ -260,9 +258,7 @@ let test_from_dependency_entries =
       ~dependency_entries:
         [
           dependency_factory ~name:"x" ~version:"v" ~url_src:(Other "u")
-            ~dev_repo:"d" ~hashes:[]
-            ~build_commands:[ ([], None) ]
-            ();
+            ~dev_repo:"d" ~hashes:[] ~has_build_commands:true ();
         ]
       ~expected:
         (Ok
@@ -286,13 +282,9 @@ let test_from_dependency_entries =
       ~dependency_entries:
         [
           dependency_factory ~name:"y" ~version:"v" ~url_src:(Other "u")
-            ~dev_repo:"d" ~hashes:[]
-            ~build_commands:[ ([], None) ]
-            ();
+            ~dev_repo:"d" ~hashes:[] ~has_build_commands:true ();
           dependency_factory ~name:"y-lwt" ~version:"v" ~url_src:(Other "u")
-            ~dev_repo:"d" ~hashes:[]
-            ~build_commands:[ ([], None) ]
-            ();
+            ~dev_repo:"d" ~hashes:[] ~has_build_commands:true ();
         ]
       ~expected:
         (Ok


### PR DESCRIPTION
Reported by @gridbugs that `xml-light.2.4` is missing `build` but is not a virtual package due to having `install`.

This simplifies the previous detection a little bit, since the build commands (and by extension the install commands) are never used, so just recording their presence or absence should be enough.