### PR TITLE
Error when multiple dev-repos collide on dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
 
 ### Fixed
 
+- Error in case where multiple packages with different dev-repo fields would be
+  placed in the same duniverse directory (#377, @gridbugs)
+
 ### Removed
 
 ### Security

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -5,7 +5,7 @@ type t = string
 let compare = String.compare
 let from_string s = s
 let to_string t = t
-let pp fmt t = Format.fprintf fmt "%s" t
+let pp = Fmt.string
 
 let rec repeat_while_some x ~f =
   match f x with None -> x | Some x -> repeat_while_some x ~f

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -5,6 +5,7 @@ type t = string
 let compare = String.compare
 let from_string s = s
 let to_string t = t
+let pp fmt t = Format.fprintf fmt "%s" t
 
 let rec repeat_while_some x ~f =
   match f x with None -> x | Some x -> repeat_while_some x ~f

--- a/lib/dev_repo.mli
+++ b/lib/dev_repo.mli
@@ -4,6 +4,7 @@ type t
 
 val from_string : string -> t
 val to_string : t -> string
+val pp : t Fmt.t
 
 val repo_name : t -> (string, Rresult.R.msg) result
 (** Computes a name for the repo by applying the following method:

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -266,20 +266,16 @@ let dev_repo_package_map_to_repos dev_repo_package_map =
     | Some (dir, dev_repos) ->
         let dir_path = Fpath.(Config.vendor_dir / dir) in
         let message_first_line =
-          Format.asprintf
-            "Multiple dev-repos would be vendored into the directory: %a"
+          Fmt.str "Multiple dev-repos would be vendored into the directory: %a"
             Fpath.pp dir_path
         in
-        let message_dev_repos =
-          Format.sprintf "Dev-repos:\n%s"
-            (List.map dev_repos ~f:(fun dev_repo ->
-                 Format.asprintf "- %a" Dev_repo.pp dev_repo)
-            |> String.concat ~sep:"\n")
+        let dev_repos_pp =
+          Fmt.list
+            ~sep:Fmt.(const char '\n')
+            (fun ppf dev_repo -> Fmt.pf ppf "- %a" Dev_repo.pp dev_repo)
         in
-        let message =
-          [ message_first_line; message_dev_repos ] |> String.concat ~sep:"\n"
-        in
-        Error (`Msg message)
+        Rresult.R.error_msgf "%s\nDev-repos:\n%a" message_first_line
+          dev_repos_pp dev_repos
   in
   Ok (List.map ~f:snd repo_by_dev_repo)
 

--- a/test/bin/error-on-directory-conflict.t/repo/packages/bar/bar.0.1.0/opam
+++ b/test/bin/error-on-directory-conflict.t/repo/packages/bar/bar.0.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+dev-repo: "git+https://github.com/bar/project"
+depends: [
+  "dune"
+]
+build: [ "dune" "build" ]
+url {
+  src: "https://test.com/bar.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/error-on-directory-conflict.t/repo/packages/foo-branch/foo-branch.0.1.0/opam
+++ b/test/bin/error-on-directory-conflict.t/repo/packages/foo-branch/foo-branch.0.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+dev-repo: "git+https://github.com/foo/project.git#branch"
+depends: [
+  "dune"
+]
+build: [ "dune" "build" ]
+url {
+  src: "https://test.com/foo-branch.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/error-on-directory-conflict.t/repo/packages/foo/foo.0.1.0/opam
+++ b/test/bin/error-on-directory-conflict.t/repo/packages/foo/foo.0.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+dev-repo: "git+https://github.com/foo/project"
+depends: [
+  "dune"
+]
+build: [ "dune" "build" ]
+url {
+  src: "https://test.com/foo.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/error-on-directory-conflict.t/run.t
+++ b/test/bin/error-on-directory-conflict.t/run.t
@@ -1,0 +1,16 @@
+We have a project which depends on multiple packages with different dev-repos
+but which happen to resolve to the same directory under duniverse. This tests
+that such a situation results in an explicit error.
+
+  $ gen-minimal-repo
+  $ opam-monorepo lock
+  ==> Using 1 locally scanned package as the target.
+  ==> Found 11 opam dependencies for the target package.
+  ==> Querying opam database for their metadata and Dune compatibility.
+  ==> Calculating exact pins for each of them.
+  opam-monorepo: [ERROR] Multiple dev-repos would be vendored into the directory: duniverse/project
+  Dev-repos:
+  - git+https://github.com/foo/project.git#branch
+  - git+https://github.com/foo/project
+  - git+https://github.com/bar/project
+  [1]

--- a/test/bin/error-on-directory-conflict.t/x.opam
+++ b/test/bin/error-on-directory-conflict.t/x.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "foo"
+  "foo-branch"
+  "bar"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]


### PR DESCRIPTION
The duniverse directory of a package is implied by its dev-repo. It's possible for different dev-repos to map to the same directory. Prior to this change, one lucky package would be downloaded to the expected place and the others would be silently ignored. More precisely, each package would be downloaded and placed in the duniverse dir implied by their dev-repo, but first any existing duniverse dir of the same name would be removed.

After this change, the same situation results in an error when running `opam monorepo lock`.