### PR TITLE
Fix a failure when using opam-monorepo with an opam 2.2 root

### DIFF
--- a/bin/opam_monorepo.ml
+++ b/bin/opam_monorepo.ml
@@ -21,7 +21,7 @@ let cmds = [ Lock.cmd; Pull.cmd; Depext.cmd; List_cmd.cmd ]
 let init_opam () =
   OpamSystem.init ();
   let root = OpamStateConfig.opamroot () in
-  ignore (OpamStateConfig.load_defaults root);
+  ignore (OpamStateConfig.load_defaults ~lock_kind:`Lock_read root);
   OpamFormatConfig.init ();
   OpamCoreConfig.init ~safe_mode:true ();
   OpamRepositoryConfig.init ();


### PR DESCRIPTION
When using `opam-monorepo.0.3.5` (which vendors the opam 2.1.3 libraries) with an opam root upgraded to opam master (2.2.0~alpha) this error appears when opam-monorepo is used:
```
#=== ERROR while compiling mirage.4.3.5 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.10.2 | pinned(https://github.com/mirage/mirage/releases/download/v4.3.5/mirage-4.3.5.tbz)
# path                 ~/.opam/4.10/.opam-switch/build/mirage.4.3.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p mirage -j 255
# exit-code            1
# env-file             ~/.opam/log/mirage-7-175471.env
# output-file          ~/.opam/log/mirage-7-175471.out
### output ###
# File "test/opam-monorepo/lock.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/19c70e9bc17d00b89787de4f1bba3a5d/default/test/opam-monorepo/lock.t _build/.sandbox/19c70e9bc17d00b89787de4f1bba3a5d/default/test/opam-monorepo/lock.t.corrected
# diff --git a/_build/.sandbox/19c70e9bc17d00b89787de4f1bba3a5d/default/test/opam-monorepo/lock.t b/_build/.sandbox/19c70e9bc17d00b89787de4f1bba3a5d/default/test/opam-monorepo/lock.t.corrected
# index aa08149..fa6a976 100644
# --- a/_build/.sandbox/19c70e9bc17d00b89787de4f1bba3a5d/default/test/opam-monorepo/lock.t
# +++ b/_build/.sandbox/19c70e9bc17d00b89787de4f1bba3a5d/default/test/opam-monorepo/lock.t.corrected
# @@ -1,41 +1,12 @@
#    $ opam-monorepo lock --require-cross-compile
# -  ==> Using 1 locally scanned package as the target.
# -  ==> Found 8 opam dependencies for the target package.
# -  ==> Querying opam database for their metadata and Dune compatibility.
# -  ==> Calculating exact pins for each of them.
# -  ==> Wrote lockfile with 4 entries to $TESTCASE_ROOT/unikernel.opam.locked. You can now run opam monorepo pull to fetch their sources.
# +  [ERROR] Refusing write access to /home/opam/.opam, which is more recent than this version of opam (2.2~alpha > 2.1), aborting.
# +  Fatal error: exception OpamStd.OpamSys.Exit(15)
# +  Raised at file "duniverse/opam/src/core/opamStd.ml", line 1042, characters 15-29
# +  Called from file "duniverse/opam/src/state/opamStateConfig.ml", line 352, characters 12-36
# +  Called from file "bin/opam_monorepo.ml", line 24, characters 9-45
# +  Called from file "bin/opam_monorepo.ml", line 67, characters 2-14
# +  [2]
```
See https://github.com/ocaml/opam/pull/5488 and https://github.com/ocaml/opam/issues/5487