### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,8 +4,8 @@ RUN opam install -y dune
 COPY --chown=opam . /home/opam/src/
 WORKDIR /home/opam/src
 ENV DUNE_CACHE=enabled
-RUN --mount=type=cache,target=/home/opam/.cache,uid=1000 opam exec -- dune build --profile=static @install
-RUN --mount=type=cache,target=/home/opam/.cache,uid=1000 opam exec -- dune install
+RUN --mount=type=cache,target=/home/opam/.cache,uid=1000 opam exec -- dune build --profile=static @install \
+    && --mount=type=cache,target=/home/opam/.cache,uid=1000 opam exec -- dune install
 
 # no-ocaml
 FROM alpine:3.12 as no-ocaml
@@ -14,9 +14,9 @@ COPY --from=base /home/opam/.opam/4.10/bin/duniverse /usr/bin/duniverse
 RUN apk add --update musl-dev gcc g++ make git
 COPY --chown=opam . /src/
 WORKDIR /src
-RUN --mount=type=cache,target=/home/opam/.cache,sharing=locked,uid=1000 duniverse pull
 RUN --mount=type=cache,target=/home/opam/.cache,sharing=private,uid=1000 duniverse tools -vv
-RUN --mount=type=cache,target=/home/opam/.cache,sharing=private,uid=1000 duniverse tools -vv
+RUN --mount=type=cache,target=/home/opam/.cache,sharing=locked,uid=1000 duniverse pull \
+    && --mount=type=cache,target=/home/opam/.cache,sharing=private,uid=1000 duniverse tools -vv
 
 # ocaml-too-old
 FROM alpine:3.8 as ocaml-too-old


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile.test" contains the best practice violation [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs if there are multiple consecutive RUN instructions. Each RUN will correspond to a layer of the final Docker image, thus is recommended to compact them to reduce the number of layers for the final image.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, The consecutive RUN instructions have been chained until a comment or a different instruction appears.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
