### PR TITLE
Simplify error message when deps don't build with dune

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
   semantically equivalent URLs, this should reduce the risk of build failures
   due to duplicate code pulled (#118, #365 @TheLortex, @Leonidas-from-XIV)
 
+- Simple the error message printed when dependencies don't use dune as their
+  build system. The opam-0install diagnostic message is no longer printed in
+  this case and the message has been reformatted and reworded to make the
+  salient information easier to see. (#384, @gridbugs)
+
 ### Deprecated
 
 ### Fixed

--- a/test/bin/no-build-command.t/run.t
+++ b/test/bin/no-build-command.t/run.t
@@ -21,8 +21,8 @@ Attempt to generate a lockfile for a package which depends on
 depend-without-dune (this should fail due to the transitive dependency on
 without-dune which has a build command but doesn't depend on dune)
 
-  $ opam-monorepo lock test-depend-without-dune.opam 2>&1 | grep -o "Doesn't build with dune"
-  Doesn't build with dune
+  $ opam-monorepo lock test-depend-without-dune.opam 2>&1 | grep -o "Some dependencies cannot be built with dune!"
+  Some dependencies cannot be built with dune!
 
 Attempt to generate a lockfile for a package which depends only on
 depend-with-dune


### PR DESCRIPTION
When trying to generate a lockfile on a package which has dependencies which don't use dune as their build system, the diagnostic message generated by opam-0install is of little use. This change removes the opam-0install diagnostic message from the output of `opam monorepo lock` in the case where it fails due to dependencies not building with dune.

Additionally this rewords the error message to highlight the salient information. In particular the list of non-dune packages is printed as a bulleted list rather than a comma-separated list inside the error message (it often takes me a minute to find the list of packages in the old error message).