### PR TITLE
Use `is_prefix` which is available in OCaml 4.10

### DIFF
--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -541,7 +541,7 @@ let extract_source_config ~adjustment ~opam_monorepo_cwd ~opam_files
 
 let raw_cli_args () =
   match Array.to_list Sys.argv with
-  | _bin :: prefix :: args when String.starts_with ~prefix "lock" -> args
+  | _bin :: prefix :: args when Base.String.is_prefix ~prefix "lock" -> args
   | _ -> assert false
 
 let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)


### PR DESCRIPTION
#381 introduced an additional check, but unfortunately `String.starts_with` was only added in OCaml 4.13. This PR uses an equivalent function from Base that is available in OCaml 4.10.