### PR TITLE
Remove backslash escape from `grep` call

### DIFF
--- a/test/bin/empty-duniverse.t/run.t
+++ b/test/bin/empty-duniverse.t/run.t
@@ -15,7 +15,7 @@ We should be able to successfully lock:
 
 And the lock file should not contain anything to vendor:
 
-  $ opam show --just-file -fdepends ./empty-duniverse.opam.locked | grep "\?vendor"
+  $ opam show --just-file -fdepends ./empty-duniverse.opam.locked | grep "?vendor"
   [1]
 
 Finally, we should be able to pull this lock file, the tool will inform us that


### PR DESCRIPTION
Apparently `grep` now warns about this, causing a test failure:

```
diff --git a/_build/.sandbox/89b1e78a9e8830d72e7bb32e1bc4651d/default/test/bin/empty-duniverse.t/run.t b/_build/.sandbox/89b1e78a9e8830d72e7bb32e1bc4651d/default/test/bin/empty-duniverse.t/run.t.corrected
index 3380874c..1601055d 100644
--- a/_build/.sandbox/89b1e78a9e8830d72e7bb32e1bc4651d/default/test/bin/empty-duniverse.t/run.t
+++ b/_build/.sandbox/89b1e78a9e8830d72e7bb32e1bc4651d/default/test/bin/empty-duniverse.t/run.t.corrected
@@ -16,6 +16,7 @@ We should be able to successfully lock:
 And the lock file should not contain anything to vendor:
 
   $ opam show --just-file -fdepends ./empty-duniverse.opam.locked | grep "\?vendor"
+  grep: warning: stray \ before ?
   [1]
 
 Finally, we should be able to pull this lock file, the tool will inform us that
```