### PR TITLE
Remove flaky test

### DIFF
--- a/test/bin/depext.t/run.t
+++ b/test/bin/depext.t/run.t
@@ -20,9 +20,3 @@ We lock and expect the OS package to be part of the locked Opam file.
   $ opam-monorepo lock > /dev/null
   $ opam show --just-file --raw -fdepexts ./depext.opam.locked
   libfantasydependency
-
-Then we want to make sure `depext` works. Given the fantasy package does not
-exist, `depext` should not install any packages but still work successfully:
-
-  $ opam-monorepo depext --dry-run
-  ==> Using lockfile $TESTCASE_ROOT/depext.opam.locked


### PR DESCRIPTION
As https://github.com/ocaml/opam/pull/4791 removed support for detection of available packages on Fedora and according to @kit-ty-kate the detection is very dependent on the system, this test is too flaky to be useful.