### PR TITLE
Remove custom deduplication of packages and use opam solver instead

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
   this case and the message has been reformatted and reworded to make the
   salient information easier to see. (#384, @gridbugs)
 
+- Encode `dev-repo` constraints in the opam solver - this allows to resolve
+  more involved version constraints that were failing before (#396, @samoht)
+
 ### Deprecated
 
 ### Fixed

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -32,3 +32,10 @@ module Map = Map.Make (struct
 
   let compare = compare
 end)
+
+module Tbl = Hashtbl.Make (struct
+  type nonrec t = t
+
+  let hash = Hashtbl.hash
+  let equal = String.equal
+end)

--- a/lib/dev_repo.mli
+++ b/lib/dev_repo.mli
@@ -21,3 +21,4 @@ val repo_name : t -> (string, Rresult.R.msg) result
     Returns an error if the result would be the empty string. *)
 
 module Map : Map.S with type key = t
+module Tbl : Hashtbl.S with type key = t

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -217,27 +217,6 @@ module Repo = struct
                  ];
              })
         ();
-      make_test ~name:"Pick URL from highest version package" ~dev_repo:"d"
-        ~packages:
-          [
-            package_factory ~name:"d" ~version:"1" ~url:(Other "u1") ~hashes:[]
-              ();
-            package_factory ~name:"d-lwt" ~version:"2" ~url:(Other "u2")
-              ~hashes:[] ();
-          ]
-        ~expected:
-          (Ok
-             {
-               dir = "d";
-               url = Other "u2";
-               hashes = [];
-               provided_packages =
-                 [
-                   opam_factory ~name:"d" ~version:"1";
-                   opam_factory ~name:"d-lwt" ~version:"2";
-                 ];
-             })
-        ();
       make_test ~name:"An empty string dev_repo results in an error"
         ~dev_repo:"" ~packages:[]
         ~expected:


### PR DESCRIPTION
Convert the constraint "if X and Y are from the same repository" into a conflict relationship in the opam metadata between `X` and all the version of `Y` which do not have the same exact version as `X`.

This allow to remove the adhoc post-processing of opam solution which was going very wrong in lots of case. Hopefully, the results will now be much closer to what you would expect `opam` to produce.