### PR TITLE
Ignore pinned packages when building dev-repo conflicts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 ### Deprecated
 
 ### Fixed
+- Fix support for pinned packages. In that case, it is not necessary to add
+  dev-repo conflicts as `opam-monorepo` will always use the pinned repository.
+  (#398, @samoht, reported by @emillon)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ### Fixed
 - Fix support for pinned packages. In that case, it is not necessary to add
   dev-repo conflicts as `opam-monorepo` will always use the pinned repository.
-  (#398, @samoht, reported by @emillon)
+  (#398, #353, @samoht, @reynir, reported by @emillon)
 
 ### Removed
 

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -152,7 +152,7 @@ module Repo = struct
           "The following packages come from the same repository %s but are \
            associated with different URLs:\n\
            %a\n\
-           The url for the pinned package(s) was selected: %a"
+           The URL for the pinned package(s) was selected: %a"
           (Dev_repo.to_string dev_repo)
           (Fmt.list ~sep pp_package) packages
           Fmt.(list ~sep pp_package)

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -37,6 +37,7 @@ module Repo : sig
       dev_repo : string;
       url : unresolved Url.t;
       hashes : OpamHash.t list;
+      pinned : bool;
     }
 
     val equal : t -> t -> bool

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -195,6 +195,7 @@ module Package_summary = struct
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
+    pinned : bool;
     flags : Package_flag.t list;
     has_build_commands : bool;
     has_install_commands : bool;
@@ -207,6 +208,7 @@ module Package_summary = struct
         hashes;
         dev_repo;
         depexts;
+        pinned;
         flags;
         has_build_commands;
         has_install_commands;
@@ -214,16 +216,16 @@ module Package_summary = struct
     let open Pp_combinators.Ocaml in
     Format.fprintf fmt
       "@[<hov 2>{ name = %a;@ version = %a;@ url_src = %a;@ hashes = %a;@ \
-       dev_repo = %a;@ depexts = %a;@ flags = %a;@ has_build_commands = %B;@ \
-       has_install_commands = %B}@]"
+       dev_repo = %a;@ depexts = %a;@ pinned = %b;@ flags = %a;@ \
+       has_build_commands = %B;@ has_install_commands = %B}@]"
       Pp.package_name package.name Pp.version package.version
       (option ~brackets:true Url.pp)
       url_src (list Hash.pp) hashes
       (option ~brackets:true string)
-      dev_repo Depexts.pp depexts (list Package_flag.pp) flags
+      dev_repo Depexts.pp depexts pinned (list Package_flag.pp) flags
       has_build_commands has_install_commands
 
-  let from_opam package opam_file =
+  let from_opam package ~pinned opam_file =
     let url_field = OpamFile.OPAM.url opam_file in
     let url_src = Base.Option.map ~f:Url.from_opam_field url_field in
     let hashes =
@@ -245,6 +247,7 @@ module Package_summary = struct
       hashes;
       dev_repo;
       depexts;
+      pinned;
       flags;
       has_build_commands;
       has_install_commands;

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -216,7 +216,7 @@ module Package_summary = struct
     let open Pp_combinators.Ocaml in
     Format.fprintf fmt
       "@[<hov 2>{ name = %a;@ version = %a;@ url_src = %a;@ hashes = %a;@ \
-       dev_repo = %a;@ depexts = %a;@ pinned = %b;@ flags = %a;@ \
+       dev_repo = %a;@ depexts = %a;@ pinned = %B;@ flags = %a;@ \
        has_build_commands = %B;@ has_install_commands = %B}@]"
       Pp.package_name package.name Pp.version package.version
       (option ~brackets:true Url.pp)

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -20,13 +20,14 @@ module Package_summary : sig
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
+    pinned : bool;
     flags : OpamTypes.package_flag list;
     has_build_commands : bool;
     has_install_commands : bool;
   }
 
   val pp : t Fmt.t
-  val from_opam : OpamPackage.t -> OpamFile.OPAM.t -> t
+  val from_opam : OpamPackage.t -> pinned:bool -> OpamFile.OPAM.t -> t
 
   val is_safe_package : t -> bool
   (** A package is safe when it is clear that it can be added to the lockfile

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -844,23 +844,24 @@ struct
       =
     let env varname = String.Map.find_opt varname env in
     let pins = OpamPackage.Set.of_list pins in
+    let pkg_of_opam pkg =
+      let name = OpamFile.OPAM.name pkg in
+      let version = OpamFile.OPAM.version pkg in
+      OpamPackage.create name version
+    in
     (* remove pinned packages from the universe -- as that's what's the
        opam solver is doing. *)
-    let pp_pkg ppf pkg =
-      Fmt.pf ppf "%s.%s"
-        (OpamPackage.Name.to_string (OpamFile.OPAM.name pkg))
-        (OpamPackage.Version.to_string (OpamFile.OPAM.version pkg))
-    in
     let pkgs =
-      List.filter pkgs ~f:(fun pkg ->
+      List.filter pkgs ~f:(fun opam ->
+          let pkg = pkg_of_opam opam in
           let keep =
             match
-              OpamPackage.package_of_name_opt pins (OpamFile.OPAM.name pkg)
+              OpamPackage.package_of_name_opt pins (OpamPackage.name pkg)
             with
             | None -> true
-            | Some pin -> OpamFile.OPAM.version pkg = OpamPackage.version pin
+            | Some pin -> OpamPackage.version pkg = OpamPackage.version pin
           in
-          Logs.debug (fun l -> l "keep %a = %b" pp_pkg pkg keep);
+          Logs.debug (fun l -> l "keep %a = %b" Opam.Pp.package pkg keep);
           keep)
     in
     { pkgs; constraints; test; env; pins }

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -13,7 +13,8 @@ val local_opam_config_solver : (switch, switch_diagnostics) t
 val explicit_repos_solver :
   (opam_env * explicit_repos, explicit_repos_diagnostics) t
 
-val mock_solver : (opam_env * OpamFile.OPAM.t list, mock_diagnostics) t
+val mock_solver :
+  (opam_env * OpamFile.OPAM.t list * OpamPackage.t list, mock_diagnostics) t
 
 val calculate :
   build_only:bool ->

--- a/test/lib/dune
+++ b/test/lib/dune
@@ -1,5 +1,5 @@
 (test
  (name test_duniverse_lib)
- (libraries alcotest duniverse_lib)
+ (libraries alcotest duniverse_lib logs.fmt)
  (action
   (run %{test} -e)))

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -28,8 +28,8 @@ let opam_factory ~name ~version =
   OpamPackage.create name version
 
 let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
-    ?(hashes = []) ?(depexts = []) ?(flags = []) ?(has_build_commands = false)
-    ?(has_install_commands = false) () =
+    ?(hashes = []) ?(depexts = []) ?(pinned = false) ?(flags = [])
+    ?(has_build_commands = false) ?(has_install_commands = false) () =
   let package = opam_factory ~name ~version in
   {
     Opam.Package_summary.package;
@@ -37,6 +37,7 @@ let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
     url_src;
     hashes;
     depexts;
+    pinned;
     flags;
     has_build_commands;
     has_install_commands;
@@ -82,6 +83,7 @@ module Repo = struct
                  dev_repo = "d";
                  url = Other "u";
                  hashes = [];
+                 pinned = false;
                })
       in
       [
@@ -126,16 +128,17 @@ module Repo = struct
                     dev_repo = "d";
                     url = Git { repo = "r"; ref = "master" };
                     hashes = [];
+                    pinned = false;
                   }))
           ();
       ]
   end
 
   let package_factory ?(name = "") ?(version = "") ?(dev_repo = "")
-      ?(url = Duniverse.Repo.Url.Other "") ?(hashes = []) () =
+      ?(url = Duniverse.Repo.Url.Other "") ?(hashes = []) ?(pinned = false) () =
     let open Duniverse.Repo.Package in
     let opam = opam_factory ~name ~version in
-    { opam; dev_repo; url; hashes }
+    { opam; dev_repo; url; hashes; pinned }
 
   let test_from_packages =
     let make_test ~name ~dev_repo ~packages ~expected () =

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -74,18 +74,18 @@ module Repo = struct
         summary_factory ~dev_repo:"d" ~url_src:(Other "u") ~name:"y"
           ~version:"v" ~hashes:[] ?has_build_commands ?has_install_commands
       in
-      let simple_package =
-        Ok
-          (Some
-             Duniverse.Repo.Package.
-               {
-                 opam = opam_factory ~name:"y" ~version:"v";
-                 dev_repo = "d";
-                 url = Other "u";
-                 hashes = [];
-                 pinned = false;
-               })
+      let pkg =
+        Duniverse.Repo.Package.
+          {
+            opam = opam_factory ~name:"y" ~version:"v";
+            dev_repo = "d";
+            url = Other "u";
+            hashes = [];
+            pinned = false;
+          }
       in
+      let simple_package = Ok (Some pkg) in
+      let pinned_package = Ok (Some { pkg with pinned = true }) in
       [
         make_test ~name:"Base package"
           ~summary:(summary_factory ~name:"dune" ())
@@ -99,6 +99,9 @@ module Repo = struct
         make_test ~name:"Regular"
           ~summary:(simple_summary ~has_build_commands:true ())
           ~expected:simple_package ();
+        make_test ~name:"pinned"
+          ~summary:(simple_summary ~has_build_commands:true ~pinned:true ())
+          ~expected:pinned_package ();
         make_test ~name:"Has only install commands"
           ~summary:(simple_summary ~has_install_commands:true ())
           ~expected:simple_package ();

--- a/test/lib/test_duniverse_lib.ml
+++ b/test/lib/test_duniverse_lib.ml
@@ -1,4 +1,8 @@
 let () =
+  Logs.set_level (Some Logs.Debug);
+  Logs.set_reporter (Logs_fmt.reporter ())
+
+let () =
   Alcotest.run "Duniverse"
     [
       Test_dev_repo.suite;

--- a/test/lib/test_solve.ml
+++ b/test/lib/test_solve.ml
@@ -1,4 +1,4 @@
-let calculate universe root expected =
+let calculate universe ?(pins = []) root expected =
   let preferred_versions = OpamPackage.Name.Map.empty in
   let local_opam_files = OpamPackage.Name.Map.empty in
   let target_packages =
@@ -12,7 +12,7 @@ let calculate universe root expected =
   match
     Duniverse_lib.Opam_solve.calculate ~build_only:false ~allow_jbuilder:false
       ~require_cross_compile:false ~preferred_versions ~local_opam_files
-      ~target_packages ~opam_provided ~pin_depends solver (opam_env, pkgs)
+      ~target_packages ~opam_provided ~pin_depends solver (opam_env, pkgs, pins)
   with
   | Ok es ->
       let es =
@@ -151,47 +151,84 @@ depends: ["p1" "p2"]
   calculate universe root
     [ ("ocaml-base-compiler", "3.14"); ("p1", "1"); ("p2", "1"); ("root", "0") ]
 
-let conflict_url () =
-  let universe =
-    List.map OpamFile.OPAM.read_from_string
-      [
-        {|
+let universe_with_url =
+  List.map OpamFile.OPAM.read_from_string
+    [
+      {|
 opam-version: "2.0"
 name: "ocaml-base-compiler"
 version: "3.14"
 |};
-        {|
+      {|
 opam-version: "2.0"
 name: "p1"
 version: "1"
 dev-repo: "x"
 url {
   src: "https://p.com/p.tbz"
-  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000003"
+  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000001"
 }
 |};
-        {|
+      {|
 opam-version: "2.0"
 name: "p1"
 version: "2"
 dev-repo: "x"
 url {
   src: "https://p.com/p.tbz"
-  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000042"
+  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000002"
 }
 |};
-        {|
+      {|
 opam-version: "2.0"
 name: "p2"
 version: "1"
 dev-repo: "x"
 url {
   src: "https://p.com/p.tbz"
-  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000003"
+  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000001"
 }
 |};
-      ]
+      {|
+opam-version: "2.0"
+name: "p2"
+version: "2"
+dev-repo: "x"
+url {
+  src: "https://p.com/p.tbz"
+  checksum: "sha256=0000000000000000000000000000000000000000000000000000000000000002"
+}
+|};
+    ]
+
+let conflict_url () =
+  let universe = universe_with_url in
+  let root =
+    OpamFile.OPAM.read_from_string
+      {|
+opam-version: "2.0"
+name: "root"
+version: "0"
+depends: ["p1" {= "1"} "p2"]
+|}
   in
+  calculate universe root
+    [ ("ocaml-base-compiler", "3.14"); ("p1", "1"); ("p2", "1"); ("root", "0") ]
+
+let no_conflict_with_pin () =
+  let p2_dev =
+    OpamFile.OPAM.read_from_string
+      {|
+opam-version: "2.0"
+name: "p2"
+version: "0"
+dev-repo: "x"
+url {
+  src: "git+https://x#hash"
+}
+|}
+  in
+  let universe = p2_dev :: universe_with_url in
   let root =
     OpamFile.OPAM.read_from_string
       {|
@@ -201,8 +238,10 @@ version: "0"
 depends: ["p1" "p2"]
 |}
   in
-  calculate universe root
-    [ ("ocaml-base-compiler", "3.14"); ("p1", "1"); ("p2", "1"); ("root", "0") ]
+  calculate
+    ~pins:[ OpamPackage.of_string "p2.0" ]
+    universe root
+    [ ("ocaml-base-compiler", "3.14"); ("p1", "2"); ("p2", "0"); ("root", "0") ]
 
 let suite =
   ( "solve",
@@ -211,4 +250,5 @@ let suite =
       Alcotest.test_case "conflicts" `Quick conflicts;
       Alcotest.test_case "conflict_class" `Quick conflict_class;
       Alcotest.test_case "conflict_url" `Quick conflict_url;
+      Alcotest.test_case "no_conflict_with_pin" `Quick no_conflict_with_pin;
     ] )


### PR DESCRIPTION
This allows to pin a single package for multi-repository. In that case Opam-monorepo will always choose the pinned repository, so adding conflicts is just confusing the solver.