### PR TITLE
Drop dependency on base

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Drop `base` as a dependency to fix build on macos-arm (#411, @reynir, reported
+  by @gm0stache)
+
 ### Removed
 
 ### Security

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -129,10 +129,10 @@ let filter_duniverse ~to_consider (duniverse : D.Duniverse.t) =
         String.Map.of_list_map_exn duniverse ~f:(fun src -> (src.dir, src))
       in
       let unmatched, found =
-        Base.List.partition_map to_consider ~f:(fun asked ->
+        List.partition_map to_consider ~f:(fun asked ->
             match String.Map.find repos_map asked with
-            | None -> Base.Either.First asked
-            | Some found -> Base.Either.Second found)
+            | None -> Either.Left asked
+            | Some found -> Either.Right found)
       in
       match unmatched with
       | [] -> Ok found

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -15,10 +15,10 @@ let pad s max_len = Printf.sprintf "%-*s" max_len s
 let guess_pin ~version ~loc =
   let version = OpamPackage.Version.to_string version in
   (* opam-overlays *)
-  Base.String.is_suffix ~suffix:"+dune" version
-  || Base.String.is_prefix ~prefix:"https://github.com/dune-universe" loc
+  String.ends_with ~suffix:"+dune" version
+  || String.starts_with ~prefix:"https://github.com/dune-universe" loc
   (* mirage-overlays *)
-  || Base.String.is_suffix ~suffix:"+mirage" version
+  || String.ends_with ~suffix:"+mirage" version
 
 let pp_name = Fmt.(styled `Bold string)
 let pp_version = Fmt.(styled `Magenta string)

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -211,7 +211,7 @@ let pull_pin_depends ~global_state pin_depends =
             | Error _ as e, _ | Ok _, (Error _ as e) -> e
             | Ok acc, Ok r -> Ok (r :: acc))
         ~init:(Ok [])
-      |> List.rev
+      |> Result.map List.rev
     in
     OpamPackage.Name.Map.of_list (List.concat elms)
 
@@ -338,7 +338,7 @@ let make_repositories_locally_available repositories =
         | Error _ as e, _ | Ok _, (Error _ as e) -> e
         | Ok acc, Ok r -> Ok (r :: acc))
     ~init:(Ok [])
-  |> List.rev
+  |> Result.map List.rev
 
 
 let opam_env_from_global_state global_state =

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -211,6 +211,7 @@ let pull_pin_depends ~global_state pin_depends =
             | Error _ as e, _ | Ok _, (Error _ as e) -> e
             | Ok acc, Ok r -> Ok (r :: acc))
         ~init:(Ok [])
+      |> List.rev
     in
     OpamPackage.Name.Map.of_list (List.concat elms)
 
@@ -337,6 +338,7 @@ let make_repositories_locally_available repositories =
         | Error _ as e, _ | Ok _, (Error _ as e) -> e
         | Ok acc, Ok r -> Ok (r :: acc))
     ~init:(Ok [])
+  |> List.rev
 
 
 let opam_env_from_global_state global_state =

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,6 @@ code required to build a project using the dune build tool.")
  (depends
   (ocaml (>= 4.10.0))
   dune-build-info
-  base
   bos
   (cmdliner (>= 1.1.0))
   fmt

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -25,7 +25,7 @@ let repo_name t =
   let path = Uri.of_string t |> Uri.path in
   match Re.exec_opt repo_name_regexp path with
   | Some group ->
-    Ok (Re.Group.get group 0)
+    Ok (Re.Group.get group 1)
   | None ->
     Rresult.R.error_msgf
       "unexpected empty string while computing name for dev_repo: \"%s\"" t

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -13,7 +13,7 @@ let repo_name_regexp =
     (seq [
         opt (char '/');
         rep (char '.');
-        group (rep (compl [ char '.'; char '/' ]));
+        group (rep1 (compl [ char '.'; char '/' ]));
         opt (seq [
             char '.';
             rep (compl [ char '/' ])]);

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -11,11 +11,12 @@ let repo_name_regexp =
   let open Re in
   compile
     (seq [
-        char '/';
+        opt (char '/');
         rep (char '.');
         group (rep (compl [ char '.'; char '/' ]));
-        char '.';
-        rep (compl [ char '/' ]);
+        opt (seq [
+            char '.';
+            rep (compl [ char '/' ])]);
         rep (char '/');
         stop
       ])

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -7,25 +7,27 @@ let from_string s = s
 let to_string t = t
 let pp = Fmt.string
 
-let rec repeat_while_some x ~f =
-  match f x with None -> x | Some x -> repeat_while_some x ~f
-
-(* Attempt to split a string by calling [split s], then choose a side of the
-   result with [side], returning [s] if a split is not possible *)
-let try_split_side s ~(split : string -> (string * string) option) ~side =
-  Base.Option.value_map (split s) ~f:side ~default:s
+let repo_name_regexp =
+  let open Re in
+  compile
+    (seq [
+        char '/';
+        rep (char '.');
+        group (rep (compl [ char '.'; char '/' ]));
+        char '.';
+        rep (compl [ char '/' ]);
+        rep (char '/');
+        stop
+      ])
 
 let repo_name t =
-  Uri.of_string t |> Uri.path
-  |> repeat_while_some ~f:(Base.String.chop_suffix ~suffix:"/")
-  |> try_split_side ~split:(Base.String.rsplit2 ~on:'/') ~side:snd
-  |> repeat_while_some ~f:(Base.String.chop_prefix ~prefix:".")
-  |> try_split_side ~split:(Base.String.lsplit2 ~on:'.') ~side:fst
-  |> function
-  | "" ->
-      Rresult.R.error_msgf
-        "unexpected empty string while computing name for dev_repo: \"%s\"" t
-  | non_empty -> Ok non_empty
+  let path = Uri.of_string t |> Uri.path in
+  match Re.exec_opt repo_name_regexp path with
+  | Some group ->
+    Ok (Re.Group.get group 0)
+  | None ->
+    Rresult.R.error_msgf
+      "unexpected empty string while computing name for dev_repo: \"%s\"" t
 
 module Map = Map.Make (struct
   type nonrec t = t

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,6 @@
 (library
  (name duniverse_lib)
  (libraries
-  base
   bos
   cmdliner
   fmt

--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -54,7 +54,7 @@ module Lang = struct
       Printf.sprintf "%s.%s" (Re.Group.get group 1) (Re.Group.get group 2)
     in
     let stanza = Re.Group.get group 0 in
-    Base.String.substr_replace_first ~pattern:old_ver ~with_:new_ver stanza
+    Re.replace_string (Re.compile (Re.str old_ver)) ~by:new_ver stanza
 
   let update ~version content =
     Re.replace ~all:false stanza_regexp ~f:(update_stanza ~version) content

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -257,7 +257,7 @@ let dev_repo_package_map_to_repos dev_repo_package_map =
           | Error _ as e, _ | Ok _, (Error _ as e) -> e
           | Ok acc, Ok r -> Ok (r :: acc))
       ~init:(Ok [])
-    |> List.rev
+    |> Result.map List.rev
 
   in
   (* Detect the case where multiple different dev-repos are associated with the
@@ -313,7 +313,7 @@ let from_dependency_entries ~get_default_branch dependencies =
           | Ok acc, Ok r -> Ok (r :: acc))
       ~init:(Ok [])
       results
-    |> List.rev
+    |> Result.map List.rev
   in
   let pkgs = List.filter_map ~f:Fun.id pkg_opts in
   let dev_repo_map = dev_repo_map_from_packages pkgs in
@@ -327,4 +327,4 @@ let resolve ~resolve_ref t =
         | Error _ as e, _ | Ok _, (Error _ as e) -> e
         | Ok acc, Ok r -> Ok (r :: acc))
     ~init:(Ok [])
-  |> List.rev
+  |> Result.map List.rev

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -16,13 +16,13 @@ module Repo = struct
 
     let compare compare_ref t t' =
       match (t, t') with
-      | Git _, Other _ -> Base.Ordering.to_int Base.Ordering.Less
-      | Other _, Git _ -> Base.Ordering.to_int Base.Ordering.Greater
+      | Git _, Other _ -> -1
+      | Other _, Git _ -> 1
       | Git { repo; ref }, Git { repo = repo'; ref = ref' } -> (
           let c1 = String.compare repo repo' in
-          match Base.Ordering.of_int c1 with
-          | Base.Ordering.Less | Greater -> c1
-          | Equal -> compare_ref ref ref')
+          if c1 = 0 then
+            compare_ref ref ref'
+          else c1)
       | Other s, Other s' -> String.compare s s'
 
     let pp pp_ref fmt t =
@@ -135,7 +135,7 @@ module Repo = struct
 
   let dir_name_from_dev_repo dev_repo =
     Dev_repo.repo_name dev_repo
-    |> Base.Result.map ~f:(function "dune" -> "dune_" | name -> name)
+    |> Result.map (function "dune" -> "dune_" | name -> name)
 
   let log_url_selection ~dev_repo ~packages pinned_packages =
     let url_to_string : unresolved Url.t -> string = function
@@ -201,8 +201,8 @@ module Repo = struct
     in
     String.equal dir dir'
     && Url.equal equal_ref url url'
-    && Base.List.equal Opam.Hash.equal hashes hashes'
-    && Base.List.equal OpamPackage.equal provided_packages provided_packages'
+    && List.equal ~eq:Opam.Hash.equal hashes hashes'
+    && List.equal ~eq:OpamPackage.equal provided_packages provided_packages'
 
   let pp pp_ref fmt { dir; url; hashes; provided_packages } =
     let open Pp_combinators.Ocaml in
@@ -224,7 +224,7 @@ end
 
 type t = resolved Repo.t list
 
-let equal t t' = Base.List.equal (Repo.equal Git.Ref.equal_resolved) t t'
+let equal t t' = List.equal ~eq:(Repo.equal Git.Ref.equal_resolved) t t'
 
 let pp fmt t =
   let open Pp_combinators.Ocaml in
@@ -251,7 +251,13 @@ let dev_repo_package_map_to_repos dev_repo_package_map =
     Dev_repo.Map.bindings dev_repo_to_repo_result_map
     |> List.map ~f:(fun (dev_repo, repo_result) ->
            Result.map (fun repo -> (dev_repo, repo)) repo_result)
-    |> Base.Result.all
+    |> List.fold_left
+      ~f:(fun acc r ->
+          match acc, r with
+          | Error _ as e, _ | Ok _, (Error _ as e) -> e
+          | Ok acc, Ok r -> Ok (r :: acc))
+      ~init:(Ok [])
+
   in
   (* Detect the case where multiple different dev-repos are associated with the
      same duniverse directory. *)
@@ -298,10 +304,24 @@ let from_dependency_entries ~get_default_branch dependencies =
       ~f:(Repo.Package.from_package_summary ~get_default_branch)
       summaries
   in
-  let* pkg_opts = Base.Result.all results in
-  let pkgs = Base.List.filter_opt pkg_opts in
+  let* pkg_opts =
+    List.fold_left
+      ~f:(fun acc r ->
+          match acc, r with
+          | Error _ as e, _ | Ok _, (Error _ as e) -> e
+          | Ok acc, Ok r -> Ok (r :: acc))
+      ~init:(Ok [])
+      results
+  in
+  let pkgs = List.filter_map ~f:Fun.id pkg_opts in
   let dev_repo_map = dev_repo_map_from_packages pkgs in
   dev_repo_package_map_to_repos dev_repo_map
 
 let resolve ~resolve_ref t =
-  Parallel.map ~f:(Repo.resolve ~resolve_ref) t |> Base.Result.all
+  Parallel.map ~f:(Repo.resolve ~resolve_ref) t
+  |> List.fold_left
+    ~f:(fun acc r ->
+        match acc, r with
+        | Error _ as e, _ | Ok _, (Error _ as e) -> e
+        | Ok acc, Ok r -> Ok (r :: acc))
+    ~init:(Ok [])

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -257,6 +257,7 @@ let dev_repo_package_map_to_repos dev_repo_package_map =
           | Error _ as e, _ | Ok _, (Error _ as e) -> e
           | Ok acc, Ok r -> Ok (r :: acc))
       ~init:(Ok [])
+    |> List.rev
 
   in
   (* Detect the case where multiple different dev-repos are associated with the
@@ -312,6 +313,7 @@ let from_dependency_entries ~get_default_branch dependencies =
           | Ok acc, Ok r -> Ok (r :: acc))
       ~init:(Ok [])
       results
+    |> List.rev
   in
   let pkgs = List.filter_map ~f:Fun.id pkg_opts in
   let dev_repo_map = dev_repo_map_from_packages pkgs in
@@ -325,3 +327,4 @@ let resolve ~resolve_ref t =
         | Error _ as e, _ | Ok _, (Error _ as e) -> e
         | Ok acc, Ok r -> Ok (r :: acc))
     ~init:(Ok [])
+  |> List.rev

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -76,14 +76,17 @@ module Ls_remote = struct
     | _ -> None
 
   let extract_branch branch_ref =
-    Base.String.chop_prefix branch_ref ~prefix:"refs/heads/"
-    |> Option.to_result
-         ~none:
-           (`Msg
-             (Printf.sprintf
-                "Invalid `git ls-remote --symref` output. Failed to extract \
-                 branch from ref `%s`."
-                branch_ref))
+    let refs_heads = "refs/heads/" in
+    if String.starts_with ~prefix:refs_heads branch_ref then
+      let pos = String.length refs_heads in
+      let len = String.length branch_ref - pos in
+      Ok (String.sub branch_ref ~pos ~len)
+    else Error
+        (`Msg
+           (Printf.sprintf
+              "Invalid `git ls-remote --symref` output. Failed to extract \
+               branch from ref `%s`."
+              branch_ref))
 
   let branch_of_symref ~symref output_lines =
     match List.filter_map ~f:(parse_ref_output_line ~symref) output_lines with

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -10,7 +10,7 @@ module Extra_field = struct
     | Some result, _ -> Ok result
     | None, Some default -> Ok default
     | None, None ->
-        let file_suffix_opt = Base.Option.map ~f:(Printf.sprintf " %s") file in
+        let file_suffix_opt = Option.map (Printf.sprintf " %s") file in
         let file_suffix = Option.value ~default:"" file_suffix_opt in
         Error
           (`Msg
@@ -22,8 +22,8 @@ module Version = struct
   type t = int * int
 
   let compare (major, minor) (major', minor') =
-    match Base.Ordering.of_int (Int.compare major major') with
-    | Base.Ordering.Equal -> Base.Ordering.of_int (Int.compare minor minor')
+    match Int.compare major major' with
+    | 0 -> Int.compare minor minor'
     | ordering -> ordering
 
   let current = (0, 3)
@@ -34,7 +34,11 @@ module Version = struct
     let err () =
       Error (`Msg (Format.sprintf "Invalid lockfile version: %S" s))
     in
-    match Base.String.lsplit2 ~on:'.' s with
+    match Option.map
+            (fun idx ->
+               (String.sub s ~pos:0 ~len:idx,
+                String.sub s ~pos:(succ idx) ~len:(String.length s - idx - 1)))
+            (String.index_opt s '.') with
     | None -> err ()
     | Some (major, minor) -> (
         match (int_of_string_opt major, int_of_string_opt minor) with
@@ -43,13 +47,14 @@ module Version = struct
 
   let compatible t =
     match compare current t with
-    | Base.Ordering.Equal -> Ok ()
-    | Less ->
+    | 0 -> Ok ()
+    | n  ->
+      if n < 0 then
         Rresult.R.error_msgf
           "Incompatible opam-monorepo lockfile version %a. Please upgrade your \
            opam-monorepo plugin."
           pp t
-    | Greater ->
+      else
         Rresult.R.error_msgf
           "opam-monorepo lockfile version %a is too old. Please regenerate the \
            lockfile using your current opam-monorepo plugin or install an \
@@ -321,12 +326,14 @@ let depends t = t.depends
 
 let url_to_duniverse_url url =
   let url_res = Duniverse.Repo.Url.from_opam_url url in
-  Base.Result.map_error url_res ~f:(function `Msg msg ->
-      let msg =
-        Printf.sprintf "Invalid-monorepo lockfile pin URL %s: %s"
-          (OpamUrl.to_string url) msg
-      in
-      `Msg msg)
+  Result.map_error
+    (function `Msg msg ->
+       let msg =
+         Printf.sprintf "Invalid-monorepo lockfile pin URL %s: %s"
+           (OpamUrl.to_string url) msg
+       in
+       `Msg msg)
+    url_res
 
 let to_duniverse { duniverse_dirs; pin_depends; _ } =
   let open Result.O in

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -49,7 +49,7 @@ let pull_source_dependencies ?trim_clone ~global_state ~duniverse_dir src_deps =
          | Error _ as e, _ | Ok _, (Error _ as e) -> e
          | Ok acc, Ok r -> Ok (r :: acc))
       ~init:(Ok [])
-    |> List.rev
+    |> Result.map List.rev
   in
   let total = List.length src_deps in
   let pp_count = Pp.Styled.good Fmt.int in

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -43,7 +43,12 @@ let pull_source_dependencies ?trim_clone ~global_state ~duniverse_dir src_deps =
     OpamParallel.map ~jobs
       ~command:(pull ?trim_clone ~global_state ~duniverse_dir)
       src_deps
-    |> Base.Result.all
+    |> List.fold_left
+      ~f:(fun acc r ->
+         match acc, r with
+         | Error _ as e, _ | Ok _, (Error _ as e) -> e
+         | Ok acc, Ok r -> Ok (r :: acc))
+      ~init:(Ok [])
   in
   let total = List.length src_deps in
   let pp_count = Pp.Styled.good Fmt.int in
@@ -132,7 +137,7 @@ let filter_preserved ~preserved duniverse =
 
 let duniverse ~full ~preserve_symlinks ~root ~global_state ~trim_clone duniverse
     =
-  if Base.List.is_empty duniverse then Ok ()
+  if duniverse = [] then Ok ()
   else
     let open Result.O in
     let duniverse_dir = Fpath.(root // Config.vendor_dir) in

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -49,6 +49,7 @@ let pull_source_dependencies ?trim_clone ~global_state ~duniverse_dir src_deps =
          | Error _ as e, _ | Ok _, (Error _ as e) -> e
          | Ok acc, Ok r -> Ok (r :: acc))
       ~init:(Ok [])
+    |> List.rev
   in
   let total = List.length src_deps in
   let pp_count = Pp.Styled.good Fmt.int in

--- a/lib/serial_shape.ml
+++ b/lib/serial_shape.ml
@@ -279,7 +279,7 @@ let rec equal : type a. a t -> a -> a -> bool =
   | Sstring, s, s' -> String.equal s s'
   | Spair (sfst, ssnd), (fst, snd), (fst', snd') ->
       equal sfst fst fst' && equal ssnd snd snd'
-  | Slist s, l, l' -> Base.List.equal (equal s) l l'
+  | Slist s, l, l' -> List.equal ~eq:(equal s) l l'
   | Choice2 (s, _), `C1 v, `C1 v' -> equal s v v'
   | Choice2 (_, s), `C2 v, `C2 v' -> equal s v v'
   | Choice2 _, _, _ -> false

--- a/lib/source_opam_config.ml
+++ b/lib/source_opam_config.ml
@@ -218,7 +218,11 @@ module Opam_repositories_url_rewriter = struct
     match url.OpamUrl.transport with
     | "file" -> (
         let path_remainder =
-          Base.String.chop_prefix ~prefix:opam_monorepo_cwd url.OpamUrl.path
+          if String.starts_with ~prefix:opam_monorepo_cwd url.OpamUrl.path then
+            let pos = String.length opam_monorepo_cwd in
+            let len = String.length url.OpamUrl.path - pos in
+            Some (String.sub url.OpamUrl.path ~pos ~len)
+          else None
         in
         match path_remainder with
         | Some r ->
@@ -268,7 +272,7 @@ let get ~opam_monorepo_cwd opam_file =
   Ok { global_vars; repositories; opam_provided }
 
 let set_field set var opam_file =
-  Base.Option.value_map ~default:opam_file var ~f:(fun v -> set v opam_file)
+  Option.value ~default:opam_file (Option.map (fun v -> set v opam_file) var)
 
 let set ~opam_monorepo_cwd { global_vars; repositories; opam_provided }
     opam_file =

--- a/lib/uri_utils.ml
+++ b/lib/uri_utils.ml
@@ -7,10 +7,18 @@ module Normalized = struct
     match Uri.host uri with
     | Some "github.com" -> (
         let path = Uri.path uri in
-        match Base.String.lsplit2 path ~on:'/' with
+        match Option.map
+                (fun idx ->
+                   (String.sub path ~pos:0 ~len:idx,
+                    String.sub path ~pos:(succ idx) ~len:(String.length path - idx - 1)))
+                (String.index_opt path '/') with
         | None -> Other uri
         | Some (user, gitrepo) -> (
-            match Base.String.rsplit2 gitrepo ~on:'.' with
+            match Option.map
+                    (fun idx ->
+                       (String.sub gitrepo ~pos:0 ~len:idx,
+                        String.sub gitrepo ~pos:(succ idx) ~len:(String.length gitrepo - idx - 1)))
+                    (String.rindex_opt gitrepo '.') with
             | None -> Github { user; repo = gitrepo }
             | Some (repo, "git") -> Github { user; repo }
             | Some _ -> Other uri))

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -17,7 +17,6 @@ depends: [
   "dune" {>= "3.5"}
   "ocaml" {>= "4.10.0"}
   "dune-build-info"
-  "base"
   "bos"
   "cmdliner" {>= "1.1.0"}
   "fmt"

--- a/opam-monorepo.opam.locked
+++ b/opam-monorepo.opam.locked
@@ -6,7 +6,6 @@ depends: [
   "alcotest" {= "1.6.0" & ?vendor}
   "angstrom" {= "0.15.0" & ?vendor}
   "astring" {= "0.8.5+dune" & ?vendor}
-  "base" {= "v0.15.1" & ?vendor}
   "base-bigarray" {= "base"}
   "base-bytes" {= "base+dune" & ?vendor}
   "base-domains" {= "base"}
@@ -42,13 +41,13 @@ depends: [
   "opam-format" {= "2.3.0" & ?vendor}
   "opam-repository" {= "2.3.0" & ?vendor}
   "opam-state" {= "2.3.0" & ?vendor}
-  "parsexp" {= "v0.15.0" & ?vendor}
+  "parsexp" {= "v0.16.0" & ?vendor}
   "re" {= "1.10.4" & ?vendor}
   "result" {= "1.5" & ?vendor}
   "rresult" {= "0.7.0+dune" & ?vendor}
   "seq" {= "base+dune" & ?vendor}
-  "sexplib" {= "v0.15.1" & ?vendor}
-  "sexplib0" {= "v0.15.1" & ?vendor}
+  "sexplib" {= "v0.16.0" & ?vendor}
+  "sexplib0" {= "v0.16.0" & ?vendor}
   "sha" {= "1.15.4" & ?vendor}
   "spdx_licenses" {= "1.3.0" & ?vendor}
   "stdlib-shims" {= "0.3.0" & ?vendor}
@@ -93,10 +92,6 @@ pin-depends: [
   [
     "astring.0.8.5+dune"
     "https://github.com/dune-universe/astring/archive/v0.8.5+dune.tar.gz"
-  ]
-  [
-    "base.v0.15.1"
-    "https://github.com/janestreet/base/archive/refs/tags/v0.15.1.tar.gz"
   ]
   [
     "base-bytes.base+dune"
@@ -192,8 +187,8 @@ pin-depends: [
     "https://github.com/ocaml/opam/archive/refs/tags/2.3.0.tar.gz"
   ]
   [
-    "parsexp.v0.15.0"
-    "https://ocaml.janestreet.com/ocaml-core/v0.15/files/parsexp-v0.15.0.tar.gz"
+    "parsexp.v0.16.0"
+    "https://ocaml.janestreet.com/ocaml-core/v0.16/files/parsexp-v0.16.0.tar.gz"
   ]
   [
     "re.1.10.4"
@@ -209,12 +204,12 @@ pin-depends: [
   ]
   ["seq.base+dune" "https://github.com/c-cube/seq/archive/0.2.2.tar.gz"]
   [
-    "sexplib.v0.15.1"
-    "https://github.com/janestreet/sexplib/archive/refs/tags/v0.15.1.tar.gz"
+    "sexplib.v0.16.0"
+    "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib-v0.16.0.tar.gz"
   ]
   [
-    "sexplib0.v0.15.1"
-    "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.15.1.tar.gz"
+    "sexplib0.v0.16.0"
+    "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib0-v0.16.0.tar.gz"
   ]
   [
     "sha.1.15.4"
@@ -388,33 +383,11 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://github.com/janestreet/base/archive/refs/tags/v0.15.1.tar.gz"
-    "base"
-    [
-      "sha256=755e303171ea267e3ba5af7aa8ea27537f3394d97c77d340b10f806d6ef61a14"
-    ]
-  ]
-  [
     "https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz"
     "result"
     [
       "sha256=7c3a5e238558f4c1a4f5acca816bc705a0e12f68dc0005c61ddbf2e6cab8ee32"
       "md5=1b82dec78849680b49ae9a8a365b831b"
-    ]
-  ]
-  [
-    "https://github.com/janestreet/sexplib/archive/refs/tags/v0.15.1.tar.gz"
-    "sexplib"
-    [
-      "sha256=75da7d290d92d758c01f441f9589ccce031e11301563efde1c19149d39edbcbc"
-    ]
-  ]
-  [
-    "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.15.1.tar.gz"
-    "sexplib0"
-    [
-      "sha256=e8cd817eb3bc3f84a2065fa0255ab2b986a24baf1cc329d05627c516464267b3"
-      "md5=ab8fd6273f35a792cad48cbb3024a7f9"
     ]
   ]
   [
@@ -545,10 +518,24 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://ocaml.janestreet.com/ocaml-core/v0.15/files/parsexp-v0.15.0.tar.gz"
+    "https://ocaml.janestreet.com/ocaml-core/v0.16/files/parsexp-v0.16.0.tar.gz"
     "parsexp"
     [
-      "sha256=d1ee902b12ac7c0c888863025990d06845530fb75328454814e5ce5b6d43d193"
+      "sha256=b6e2572c8e6191a85cb8f9c3276ed87fe00522c81ba7a268179fb08185e55e12"
+    ]
+  ]
+  [
+    "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib-v0.16.0.tar.gz"
+    "sexplib"
+    [
+      "sha256=e564d5d1ca157314ba5fd64b4e89fa12c6cba8efee3becf6d09d7d9dda21ac5b"
+    ]
+  ]
+  [
+    "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib0-v0.16.0.tar.gz"
+    "sexplib0"
+    [
+      "sha256=86dba26468194512f789f2fb709063515a9cb4e5c4461c021c239a369590701d"
     ]
   ]
 ]

--- a/test/lib/test_source_opam_config.ml
+++ b/test/lib/test_source_opam_config.ml
@@ -33,7 +33,7 @@ module Opam_repositories_url_rewriter = struct
         let value = OpamUrl.of_string value in
         let actual =
           Opam_repositories_url_rewriter.rewrite_one_in ~opam_monorepo_cwd value
-          |> Base.Result.map ~f:OpamUrl.to_string
+          |> Result.map OpamUrl.to_string
         in
         Alcotest.(check (result string Testable.r_msg))
           test_name expected actual
@@ -107,7 +107,7 @@ module Opam_repositories = struct
       in
       let test_fun () =
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
-        let expected = Base.Result.map ~f:t_from_input expected in
+        let expected = Result.map t_from_input expected in
         let actual =
           D.Source_opam_config.Private.Opam_repositories.from_opam_value value
         in
@@ -154,7 +154,7 @@ module Opam_repositories = struct
       in
       let test_fun () =
         let open D.Source_opam_config.Private in
-        let expected = Base.Result.map ~f:t_from_input expected in
+        let expected = Result.map t_from_input expected in
         let actual =
           Cmdliner.Arg.conv_parser Opam_repositories.cmdliner_conv value
         in
@@ -179,7 +179,7 @@ module Opam_global_vars = struct
       in
       let test_fun () =
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
-        let expected = Base.Result.map expected ~f:String.Map.of_list_exn in
+        let expected = Result.map String.Map.of_list_exn expected in
         let actual =
           D.Source_opam_config.Private.Opam_global_vars.from_opam_value value
         in
@@ -231,7 +231,7 @@ module Opam_global_vars = struct
       in
       let test_fun () =
         let open D.Source_opam_config.Private in
-        let expected = Base.Result.map expected ~f:String.Map.of_list_exn in
+        let expected = Result.map String.Map.of_list_exn expected in
         let actual =
           Cmdliner.Arg.conv_parser Opam_global_vars.cmdliner_conv value
         in
@@ -259,7 +259,7 @@ module Opam_provided = struct
       let test_fun () =
         let open D.Source_opam_config in
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
-        let expected = Base.Result.map expected ~f:t_from_input in
+        let expected = Result.map t_from_input expected in
         let actual = Private.Opam_provided.from_opam_value value in
         Alcotest.(check (result Testable.opam_package_name_set Testable.r_msg))
           test_name expected actual


### PR DESCRIPTION
This drops the dependency on base. In #410 (CC @gm0stache) it is reported that opam-monorepo fails to install on Mac OS on ARM. The error message suggests the compilation fails in base. This rewrites all calls to base to use the standard library. Certainly, there are things that could be factored out to functions, but it's mostly straight forward.

@gm0stache: can you try see if this works for you?