### PR TITLE
Avoid generating conflicts with virtual packages from the same repository

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
  
 ### Fixed
 
+- Avoid generating conflicts with virtual packages: virtual and non-virtual
+  packages in the same repository are not considered incompatible anymore
+  (#415, @shym)
+
 ### Removed
 
 ### Security

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -249,14 +249,14 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
     and has_no_command = function [] -> true | _ -> false in
     is_none (OpamFile.OPAM.url pkg)
     || has_no_command (OpamFile.OPAM.build pkg)
-    || has_no_command (OpamFile.OPAM.install pkg)
-    || (List.mem OpamTypes.Pkgflag_Conf ~set:(OpamFile.OPAM.flags pkg)
+       && has_no_command (OpamFile.OPAM.install pkg)
+    || List.mem OpamTypes.Pkgflag_Conf ~set:(OpamFile.OPAM.flags pkg)
        &&
        match OpamFile.OPAM.dev_repo pkg with
        | None -> true
        | Some u when OpamUrl.to_string u = "" -> true
-       | _ -> false)
-    (* ^ case: conf package with an empty dev_repo *)
+       | _ -> false
+  (* ^ case: conf package with an empty dev_repo *)
 
   let with_conflict t pkg =
     if is_pinned t (OpamFile.OPAM.name pkg) || is_virtual pkg then


### PR DESCRIPTION
When a repository contains both virtual and non-virtual packages, avoid the conflict that is generated because the virtual package has no `src` while the non-virtual package has one, so their hash list appear superficially incompatible.

The issue came up with `ocaml-unikraft*` packages: `ocaml-unikraft` is a virtual package to depend on one of the possible packages (according to the target architecture), but the same `dev-repo` also contains the actual non-virtual packages `ocaml-unikraft` is there to depend upon. Before this patch, `opam-monorepo` created a conflict between them.